### PR TITLE
Map tally class to device

### DIFF
--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -4,12 +4,14 @@
 #include "openmc/constants.h"
 #include "openmc/tallies/filter.h"
 #include "openmc/tallies/trigger.h"
+#include "openmc/vector.h"
 
 #include <gsl/gsl>
 #include "pugixml.hpp"
 #include "xtensor/xfixed.hpp"
 #include "xtensor/xtensor.hpp"
 
+#include <array>
 #include <memory> // for unique_ptr
 #include <unordered_map>
 #include <string>
@@ -75,6 +77,9 @@ public:
   //! A string representing the i-th score on this tally
   std::string score_name(int score_idx) const;
 
+  void copy_to_device();
+  void release_from_device();
+
   //----------------------------------------------------------------------------
   // Major public data members.
 
@@ -93,16 +98,21 @@ public:
   //! Number of realizations
   int n_realizations_ {0};
 
-  std::vector<int> scores_; //!< Filter integrands (e.g. flux, fission)
+  vector<int> scores_; //!< Filter integrands (e.g. flux, fission)
 
   //! Index of each nuclide to be tallied.  -1 indicates total material.
-  std::vector<int> nuclides_ {-1};
+  vector<int> nuclides_ {-1};
 
   //! Results for each bin -- the first dimension of the array is for the
   //! combination of filters (e.g. specific cell, specific energy group, etc.)
   //! and the second dimension of the array is for scores (e.g. flux, total
   //! reaction rate, fission reaction rate, etc.)
-  xt::xtensor<double, 3> results_;
+  double* results_;
+  size_t results_size_ {0};
+  size_t n_scores_;
+
+  double* results(gsl::index i, gsl::index j, gsl::index k);
+  std::array<size_t, 3> results_shape() const;
 
   //! True if this tally should be written to statepoint files
   bool writable_ {true};
@@ -140,13 +150,20 @@ private:
 
 namespace model {
   extern std::unordered_map<int, int> tally_map;
-  extern std::vector<std::unique_ptr<Tally>> tallies;
   extern std::vector<int> active_tallies;
   extern std::vector<int> active_analog_tallies;
   extern std::vector<int> active_tracklength_tallies;
   extern std::vector<int> active_collision_tallies;
   extern std::vector<int> active_meshsurf_tallies;
   extern std::vector<int> active_surface_tallies;
+
+  #pragma omp declare target
+  extern Tally* tallies;
+  extern size_t tallies_size;
+  extern int* device_active_tallies;
+  extern int* device_active_collision_tallies;
+  extern int* device_active_tracklength_tallies;
+  #pragma omp end declare target
 }
 
 namespace simulation {

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -111,7 +111,8 @@ public:
   size_t results_size_ {0};
   size_t n_scores_;
 
-  double* results(gsl::index i, gsl::index j, gsl::index k);
+  const double* results(gsl::index i, gsl::index j, TallyResult k) const;
+  double* results(gsl::index i, gsl::index j, TallyResult k);
   std::array<size_t, 3> results_shape() const;
 
   //! True if this tally should be written to statepoint files

--- a/include/openmc/vector.h
+++ b/include/openmc/vector.h
@@ -3,6 +3,7 @@
 
 #include <algorithm> // for copy, fill
 #include <cstdlib> // for malloc
+#include <initializer_list>
 #include <iterator> // for reverse_iterator
 #include <utility> // for swap
 
@@ -30,6 +31,7 @@ public:
   vector() : data_(nullptr), size_(0), capacity_(0) { }
   vector(size_type n) : vector() { this->resize(n); }
   vector(const_iterator begin, const_iterator end);
+  vector(std::initializer_list<T> init);
 
   // Copy/move constructors/assignments
   vector(const vector& other);
@@ -218,6 +220,13 @@ vector<T>::vector(vector<T>::const_iterator first, vector<T>::const_iterator las
   : vector(last - first)
 {
   std::copy(first, last, this->begin());
+}
+
+template<typename T>
+vector<T>::vector(std::initializer_list<T> init)
+  : vector(init.size())
+{
+  std::copy(init.begin(), init.end(), this->begin());
 }
 
 template<typename T>

--- a/src/cmfd_solver.cpp
+++ b/src/cmfd_solver.cpp
@@ -210,7 +210,7 @@ void openmc_initialize_mesh_egrid(const int meshtally_id, const int* cmfd_indice
   openmc_get_tally_index(meshtally_id, &tally_index);
 
   // Get filters assocaited with tally
-  const auto& tally_filters = model::tallies[tally_index]->filters();
+  const auto& tally_filters = model::tallies[tally_index].filters();
 
   // Get mesh filter index
   auto meshfilter_index = tally_filters[0];

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -152,8 +152,8 @@ int openmc_reset()
   model::universe_cell_counts.clear();
   model::universe_level_counts.clear();
 
-  for (auto& t : model::tallies) {
-    t->reset();
+  for (int i = 0; i < model::tallies_size; ++i) {
+    model::tallies[i].reset();
   }
 
   // Reset global tallies

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -608,15 +608,15 @@ const std::unordered_map<int, const char*> score_names = {
 void
 write_tallies()
 {
-  if (model::tallies.empty()) return;
+  if (model::tallies_size == 0) return;
 
   // Open the tallies.out file.
   std::ofstream tallies_out;
   tallies_out.open("tallies.out", std::ios::out | std::ios::trunc);
 
   // Loop over each tally.
-  for (auto i_tally = 0; i_tally < model::tallies.size(); ++i_tally) {
-    const auto& tally {*model::tallies[i_tally]};
+  for (auto i_tally = 0; i_tally < model::tallies_size; ++i_tally) {
+    const auto& tally {model::tallies[i_tally]};
 
     // Write header block.
     std::string tally_header("TALLY " + std::to_string(tally.id_));
@@ -709,7 +709,7 @@ write_tallies()
             : score_names.at(score);
           double mean, stdev;
           std::tie(mean, stdev) = mean_stdev(
-            tally.results(filter_index, score_index, 0), tally.n_realizations_);
+            tally.results(filter_index, score_index, TallyResult::VALUE), tally.n_realizations_);
           fmt::print(tallies_out, "{0:{1}}{2:<36} {3:.6} +/- {4:.6}\n",
             "", indent + 1, score_name, mean, t_value * stdev);
           score_index += 1;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -709,7 +709,7 @@ write_tallies()
             : score_names.at(score);
           double mean, stdev;
           std::tie(mean, stdev) = mean_stdev(
-            &tally.results_(filter_index, score_index, 0), tally.n_realizations_);
+            tally.results(filter_index, score_index, 0), tally.n_realizations_);
           fmt::print(tallies_out, "{0:{1}}{2:<36} {3:.6} +/- {4:.6}\n",
             "", indent + 1, score_name, mean, t_value * stdev);
           score_index += 1;

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -73,7 +73,7 @@ void run_particle_restart()
 {
   // Set verbosity high
   settings::verbosity = 10;
-  
+
   // Move read on data to device, if running on device
   move_read_only_data_to_device();
 
@@ -91,7 +91,7 @@ void run_particle_restart()
   if (settings::write_all_tracks) p.write_track_ = true;
 
   // Set all tallies to 0 for now (just tracking errors)
-  model::tallies.clear();
+  model::tallies_size = 0;
 
   // Compute random number seed
   int64_t particle_seed;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -103,8 +103,8 @@ int openmc_simulation_init()
 
 
   // Allocate tally results arrays if they're not allocated yet
-  for (auto& t : model::tallies) {
-    t->init_results();
+  for (int i = 0; i < model::tallies_size; ++i) {
+    model::tallies[i].init_results();
   }
 
   // Set up material nuclide index mapping
@@ -186,8 +186,8 @@ int openmc_simulation_finalize()
   if (settings::output_tallies && mpi::master) write_tallies();
 
   // Deactivate all tallies
-  for (auto& t : model::tallies) {
-    t->active_ = false;
+  for (int i = 0; i < model::tallies_size; ++i) {
+    model::tallies[i].active_ = false;
   }
 
   // Stop timers and show timing statistics
@@ -363,8 +363,8 @@ void initialize_batch()
   } else if (first_active) {
     simulation::time_inactive.stop();
     simulation::time_active.start();
-    for (auto& t : model::tallies) {
-      t->active_ = true;
+    for (int i = 0; i < model::tallies_size; ++i) {
+      model::tallies[i].active_ = true;
     }
   }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -689,14 +689,12 @@ void broadcast_results() {
     // Create a new datatype that consists of all values for a given filter
     // bin and then use that to broadcast. This is done to minimize the
     // chance of the 'count' argument of MPI_BCAST exceeding 2**31
-    auto& results = t->results_;
-
-    auto shape = results.shape();
+    auto shape = t->results_shape();
     int count_per_filter = shape[1] * shape[2];
     MPI_Datatype result_block;
     MPI_Type_contiguous(count_per_filter, MPI_DOUBLE, &result_block);
     MPI_Type_commit(&result_block);
-    MPI_Bcast(results.data(), shape[0], result_block, 0, mpi::intracomm);
+    MPI_Bcast(t->results_, shape[0], result_block, 0, mpi::intracomm);
     MPI_Type_free(&result_block);
   }
 

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -462,9 +462,8 @@ void load_state_point()
           tally->writable_ = false;
         } else {
 
-          auto& results = tally->results_;
-          read_tally_results(tally_group, results.shape()[0],
-            results.shape()[1], results.data());
+          read_tally_results(tally_group, tally->results_shape()[0],
+            tally->results_shape()[1], tally->results_);
           read_dataset(tally_group, "n_realizations", tally->n_realizations_);
           close_group(tally_group);
         }
@@ -811,12 +810,12 @@ void write_unstructured_mesh_results() {
 
           // construct result vectors
           std::vector<double> mean_vec, std_dev_vec;
-          for (int j = 0; j < tally->results_.shape()[0]; j++) {
+          for (int j = 0; j < tally->results_shape()[0]; j++) {
             // mean
-            double mean = tally->results_(j, nuc_score_idx, TallyResult::SUM) / n_realizations;
+            double mean = *tally->results(j, nuc_score_idx, TallyResult::SUM) / n_realizations;
             mean_vec.push_back(mean);
             // std. dev.
-            double sum_sq = tally->results_(j , nuc_score_idx, TallyResult::SUM_SQ);
+            double sum_sq = *tally->results(j , nuc_score_idx, TallyResult::SUM_SQ);
             if (n_realizations > 1) {
               double std_dev = sum_sq/n_realizations - mean*mean;
               std_dev = std::sqrt(std_dev / (n_realizations - 1));

--- a/src/tallies/derivative.cpp
+++ b/src/tallies/derivative.cpp
@@ -99,7 +99,7 @@ void
 apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
   double atom_density, int score_bin, double& score)
 {
-  const Tally& tally {*model::tallies[i_tally]};
+  const Tally& tally {model::tallies[i_tally]};
 
   if (score == 0.0) return;
 

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -669,12 +669,12 @@ void Tally::release_from_device()
 
 const double* Tally::results(gsl::index i, gsl::index j, TallyResult k) const
 {
-  return results_ + (i * n_filter_bins_ + j) * n_scores_ + static_cast<int>(k);
+  return results_ + ((i * n_scores_ + j) * 3 + static_cast<int>(k));
 }
 
 double* Tally::results(gsl::index i, gsl::index j, TallyResult k)
 {
-  return results_ + (i * n_filter_bins_ + j) * n_scores_ + static_cast<int>(k);
+  return results_ + ((i * n_scores_ + j) * 3 + static_cast<int>(k));
 }
 
 std::array<size_t, 3> Tally::results_shape() const
@@ -715,10 +715,10 @@ void read_tallies_xml()
 
   // ==========================================================================
   // READ FILTER DATA
-  
+
   // Determine number of filters
   int n_tally_filters = std::distance(root.children("filter").begin(), root.children("filter").end());
-  
+
   if (n_tally_filters > 0 ) {
     // Allocate the filter array
     model::tally_filters = static_cast<Filter*>(malloc(n_tally_filters * sizeof(Filter)));
@@ -746,9 +746,15 @@ void read_tallies_xml()
     warning("No tallies present in tallies.xml file.");
   }
 
+  // Count the number of tallies
+  model::tallies_size = std::distance(root.children("tally").begin(), root.children("tally").end());
+
+  // Resize the tallies array
+  model::tallies = static_cast<Tally*>(malloc(model::tallies_size * sizeof(Tally)));
+
+  int i = 0;
   for (auto node_tal : root.children("tally")) {
-    new(model::tallies + model::tallies_size) Tally(node_tal);
-    ++model::tallies_size;
+    new(model::tallies + i++) Tally(node_tal);
   }
 }
 

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -260,7 +260,7 @@ score_fission_delayed_dg(int i_tally, int d_bin, double score, int score_index,
 
   // Update the tally result
   #pragma omp atomic
-  tally.results_(filter_index, score_index, TallyResult::VALUE) += score*filter_weight;
+  *tally.results(filter_index, score_index, TallyResult::VALUE) += score*filter_weight;
 
   // Reset the original delayed group bin
   dg_match.bins_[i_bin] = original_bin;
@@ -494,7 +494,7 @@ score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
 
       // Update tally results
       #pragma omp atomic
-      tally.results_(filter_index, i_score, TallyResult::VALUE) += score*filter_weight;
+      *tally.results(filter_index, i_score, TallyResult::VALUE) += score*filter_weight;
 
     } else if (score_bin == SCORE_DELAYED_NU_FISSION && g != 0) {
 
@@ -540,7 +540,7 @@ score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
 
         // Update tally results
         #pragma omp atomic
-        tally.results_(filter_index, i_score, TallyResult::VALUE) += score*filter_weight;
+        *tally.results(filter_index, i_score, TallyResult::VALUE) += score*filter_weight;
       }
     }
   }
@@ -941,7 +941,7 @@ score_general_ce_nonanalog(Particle& p, int i_tally, int start_index, int filter
     case SCORE_EVENTS:
       // Simply count the number of scoring events
       #pragma omp atomic
-      tally.results_(filter_index, score_index, TallyResult::VALUE) += 1.0;
+      *tally.results(filter_index, score_index, TallyResult::VALUE) += 1.0;
       continue;
 
     case ELASTIC:
@@ -1106,7 +1106,7 @@ score_general_ce_nonanalog(Particle& p, int i_tally, int start_index, int filter
 
     // Update tally results
     #pragma omp atomic
-    tally.results_(filter_index, score_index, TallyResult::VALUE) += score*filter_weight;
+    *tally.results(filter_index, score_index, TallyResult::VALUE) += score*filter_weight;
   }
 }
 
@@ -1506,7 +1506,7 @@ score_general_ce_analog(Particle& p, int i_tally, int start_index, int filter_in
     case SCORE_EVENTS:
       // Simply count the number of scoring events
       #pragma omp atomic
-      tally.results_(filter_index, score_index, TallyResult::VALUE) += 1.0;
+      *tally.results(filter_index, score_index, TallyResult::VALUE) += 1.0;
       continue;
 
 
@@ -1630,7 +1630,7 @@ score_general_ce_analog(Particle& p, int i_tally, int start_index, int filter_in
 
     // Update tally results
     #pragma omp atomic
-    tally.results_(filter_index, score_index, TallyResult::VALUE) += score*filter_weight;
+    *tally.results(filter_index, score_index, TallyResult::VALUE) += score*filter_weight;
   }
 }
 
@@ -2255,7 +2255,7 @@ score_general_mg(Particle& p, int i_tally, int start_index, int filter_index,
     case SCORE_EVENTS:
       // Simply count the number of scoring events
       #pragma omp atomic
-      tally.results_(filter_index, score_index, TallyResult::VALUE) += 1.0;
+      *tally.results(filter_index, score_index, TallyResult::VALUE) += 1.0;
       continue;
 
 
@@ -2265,7 +2265,7 @@ score_general_mg(Particle& p, int i_tally, int start_index, int filter_index,
 
     // Update tally results
     #pragma omp atomic
-    tally.results_(filter_index, score_index, TallyResult::VALUE) += score*filter_weight;
+    *tally.results(filter_index, score_index, TallyResult::VALUE) += score*filter_weight;
   }
 }
 
@@ -2526,7 +2526,7 @@ score_surface_tally(Particle& p, const std::vector<int>& tallies)
       for (auto score_index = 0; score_index < tally.scores_.size();
            ++score_index) {
         #pragma omp atomic
-        tally.results_(filter_index, score_index, TallyResult::VALUE) += score;
+        *tally.results(filter_index, score_index, TallyResult::VALUE) += score;
       }
     }
 

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -240,7 +240,7 @@ score_fission_delayed_dg(int i_tally, int d_bin, double score, int score_index,
     FilterMatch* filter_matches)
 {
   // Save the original delayed group bin
-  auto& tally {*model::tallies[i_tally]};
+  auto& tally {model::tallies[i_tally]};
   auto i_filt = tally.filters(tally.delayedgroup_filter_);
   auto& dg_match {filter_matches[i_filt]};
   auto i_bin = dg_match.i_bin_;
@@ -417,7 +417,7 @@ double score_neutron_heating(const Particle& p, const Tally& tally, double flux,
 void
 score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
 {
-  auto& tally {*model::tallies[i_tally]};
+  auto& tally {model::tallies[i_tally]};
   auto i_eout_filt = tally.filters()[tally.energyout_filter_];
   auto i_bin = p.filter_matches_[i_eout_filt].i_bin_;
   auto bin_energyout = p.filter_matches_[i_eout_filt].bins_[i_bin];
@@ -610,7 +610,7 @@ void
 score_general_ce_nonanalog(Particle& p, int i_tally, int start_index, int filter_index,
   double filter_weight, int i_nuclide, double atom_density, double flux, NuclideMicroXS& micro)
 {
-  Tally& tally {*model::tallies[i_tally]};
+  Tally& tally {model::tallies[i_tally]};
 
   // Get the pre-collision energy of the particle.
   auto E = p.E_last_;
@@ -1120,7 +1120,7 @@ void
 score_general_ce_analog(Particle& p, int i_tally, int start_index, int filter_index,
   double filter_weight, int i_nuclide, double atom_density, double flux)
 {
-  Tally& tally {*model::tallies[i_tally]};
+  Tally& tally {model::tallies[i_tally]};
 
   // Get the pre-collision energy of the particle.
   auto E = p.E_last_;
@@ -1643,7 +1643,7 @@ void
 score_general_mg(Particle& p, int i_tally, int start_index, int filter_index,
   double filter_weight, int i_nuclide, double atom_density, double flux)
 {
-  auto& tally {*model::tallies[i_tally]};
+  auto& tally {model::tallies[i_tally]};
 
   // Set the direction and group to use with get_xs
   Direction p_u;
@@ -2279,7 +2279,7 @@ void score_analog_tally_ce(Particle& p)
     1.0 : 0.0;
 
   for (auto i_tally : model::active_analog_tallies) {
-    const Tally& tally {*model::tallies[i_tally]};
+    const Tally& tally {model::tallies[i_tally]};
 
     // Initialize an iterator over valid filter bin combinations.  If there are
     // no valid combinations, use a continue statement to ensure we skip the
@@ -2322,7 +2322,7 @@ void score_analog_tally_ce(Particle& p)
 void score_analog_tally_mg(Particle& p)
 {
   for (auto i_tally : model::active_analog_tallies) {
-    const Tally& tally {*model::tallies[i_tally]};
+    const Tally& tally {model::tallies[i_tally]};
 
     // Initialize an iterator over valid filter bin combinations.  If there are
     // no valid combinations, use a continue statement to ensure we skip the
@@ -2372,7 +2372,7 @@ score_tracklength_tally(Particle& p, double distance, bool need_depletion_rx)
   double flux = p.wgt_ * distance;
 
   for (auto i_tally : model::active_tracklength_tallies) {
-    const Tally& tally {*model::tallies[i_tally]};
+    const Tally& tally {model::tallies[i_tally]};
 
     // Initialize an iterator over valid filter bin combinations.  If there are
     // no valid combinations, use a continue statement to ensure we skip the
@@ -2445,7 +2445,7 @@ void score_collision_tally(Particle& p)
   }
 
   for (auto i_tally : model::active_collision_tallies) {
-    const Tally& tally {*model::tallies[i_tally]};
+    const Tally& tally {model::tallies[i_tally]};
 
     // Initialize an iterator over valid filter bin combinations.  If there are
     // no valid combinations, use a continue statement to ensure we skip the
@@ -2504,7 +2504,7 @@ score_surface_tally(Particle& p, const std::vector<int>& tallies)
   double current = p.wgt_last_;
 
   for (auto i_tally : tallies) {
-    auto& tally {*model::tallies[i_tally]};
+    auto& tally {model::tallies[i_tally]};
 
     // Initialize an iterator over valid filter bin combinations.  If there are
     // no valid combinations, use a continue statement to ensure we skip the

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -32,8 +32,8 @@ get_tally_uncertainty(int i_tally, int score_index, int filter_index)
 {
   const auto& tally {model::tallies[i_tally]};
 
-  auto sum = tally->results_(filter_index, score_index, TallyResult::SUM);
-  auto sum_sq = tally->results_(filter_index, score_index, TallyResult::SUM_SQ);
+  auto sum = *tally->results(filter_index, score_index, TallyResult::SUM);
+  auto sum_sq = *tally->results(filter_index, score_index, TallyResult::SUM_SQ);
 
   int n = tally->n_realizations_;
   auto mean = sum / n;
@@ -64,10 +64,9 @@ check_tally_triggers(double& ratio, int& tally_id, int& score)
       // Skip trigger if it is not active
       if (trigger.metric == TriggerMetric::not_active) continue;
 
-      const auto& results = t.results_;
-      for (auto filter_index = 0; filter_index < results.shape()[0];
+      for (auto filter_index = 0; filter_index < results_shape()[0];
            ++filter_index) {
-        for (auto score_index = 0; score_index < results.shape()[1];
+        for (auto score_index = 0; score_index < results_shape()[1];
              ++score_index) {
           // Compute the tally uncertainty metrics.
           auto uncert_pair = get_tally_uncertainty(i_tally, score_index,

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -30,7 +30,7 @@ namespace settings {
 std::pair<double, double>
 get_tally_uncertainty(int i_tally, int score_index, int filter_index)
 {
-  const auto& tally {model::tallies[i_tally]};
+  const auto& tally {&model::tallies[i_tally]};
 
   auto sum = *tally->results(filter_index, score_index, TallyResult::SUM);
   auto sum_sq = *tally->results(filter_index, score_index, TallyResult::SUM_SQ);
@@ -54,8 +54,8 @@ void
 check_tally_triggers(double& ratio, int& tally_id, int& score)
 {
   ratio = 0.;
-  for (auto i_tally = 0; i_tally < model::tallies.size(); ++i_tally) {
-    const Tally& t {*model::tallies[i_tally]};
+  for (auto i_tally = 0; i_tally < model::tallies_size; ++i_tally) {
+    const Tally& t {model::tallies[i_tally]};
 
     // Ignore tallies with less than two realizations.
     if (t.n_realizations_ < 2) continue;
@@ -64,9 +64,9 @@ check_tally_triggers(double& ratio, int& tally_id, int& score)
       // Skip trigger if it is not active
       if (trigger.metric == TriggerMetric::not_active) continue;
 
-      for (auto filter_index = 0; filter_index < results_shape()[0];
+      for (auto filter_index = 0; filter_index < t.results_shape()[0];
            ++filter_index) {
-        for (auto score_index = 0; score_index < results_shape()[1];
+        for (auto score_index = 0; score_index < t.results_shape()[1];
              ++score_index) {
           // Compute the tally uncertainty metrics.
           auto uncert_pair = get_tally_uncertainty(i_tally, score_index,


### PR DESCRIPTION
This PR maps the `Tally` class, `tallies` array, and `active_tallies` arrays to device. I tested it out with the `tally_tests/mesh` problem in our offloading benchmarks repo using Intel/NVIDIA/AMD GPUs and it works fine on all.