### PR TITLE
Change C compiler from icc to icx

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,7 +24,7 @@
             "name": "intel",
             "inherits": ["unity"],
             "cacheVariables": {
-                "CMAKE_C_COMPILER": "icc",
+                "CMAKE_C_COMPILER": "icx",
                 "CMAKE_CXX_COMPILER": "icpx"
             },
             "environment": {


### PR DESCRIPTION
For the intel preset, this makes sure we are using the same compiler version for both C and C++ (icx and icpx rather than just icc and icpx).