### PR TITLE
Update CMake required version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 project(openmc C CXX)
 
 # Set version numbers


### PR DESCRIPTION
This change increases the minimum version of CMake required from 3.3 to 3.22 for our GPU offloading version. The major motivation for this is to enforce the usage of the compiler preset file (as in older versions of cmake it will simply ignore the preset command and result in an incorrect configuration + user confusion).

Presets were first introduced in 3.19, but I found when testing with CMake 3.20 that it did not like some of the fields in our current preset file. I have tested 3.22, 3.23, and 3.24 and they all work.