### PR TITLE
Remove specific binaryDir location from preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,7 +46,6 @@
             "name": "spirv",
             "inherits": ["intel"],
             "displayName": "Intel GPUs",
-            "binaryDir": "${sourceDir}/build/spirv",
             "environment": {
                 "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64 -mllvm -vpo-paropt-atomic-free-reduction=false"
             }
@@ -55,7 +54,6 @@
             "name": "spirv_aot",
             "inherits": ["intel"],
             "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
-            "binaryDir": "${sourceDir}/build/spirv_aot",
             "environment": {
                 "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device xehp -revision_id 4 -internal_options -ze-opt-large-register-file\" -mllvm -vpo-paropt-atomic-free-reduction=false"
             }
@@ -64,7 +62,6 @@
             "name": "spirv_aot_no_workarounds",
             "inherits": ["intel"],
             "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
-            "binaryDir": "${sourceDir}/build/spirv_aot_no_workarounds",
             "environment": {
                 "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device xehp -revision_id 4\""
             }
@@ -82,7 +79,6 @@
             "name": "llvm_v100_mpi",
             "inherits": ["llvm"],
             "displayName": "LLVM Clang A100",
-            "binaryDir": "${sourceDir}/build/llvm_a100",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "mpicc",
                 "CMAKE_CXX_COMPILER": "mpic++"
@@ -95,7 +91,6 @@
             "name": "llvm_a100",
             "inherits": ["llvm"],
             "displayName": "LLVM Clang A100",
-            "binaryDir": "${sourceDir}/build/llvm_a100",
             "environment": {
                 "PRESET_CXX_FLAGS": "-fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_80"
             }
@@ -104,7 +99,6 @@
             "name": "llvm_a100_mpi",
             "inherits": ["llvm"],
             "displayName": "LLVM Clang A100",
-            "binaryDir": "${sourceDir}/build/llvm_a100",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "mpicc",
                 "CMAKE_CXX_COMPILER": "mpic++"
@@ -117,7 +111,6 @@
             "name": "llvm_a100_lto",
             "inherits": ["llvm"],
             "displayName": "LLVM Clang A100",
-            "binaryDir": "${sourceDir}/build/llvm_a100",
             "environment": {
                 "PRESET_CXX_FLAGS": "-fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_80 -foffload-lto"
             }
@@ -126,7 +119,6 @@
             "name": "llvm_mi100",
             "inherits": ["llvm"],
             "displayName": "LLVM Clang MI100",
-            "binaryDir": "${sourceDir}/build/llvm_mi100",
             "environment": {
                 "PRESET_CXX_FLAGS": "-fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908"
             }
@@ -135,7 +127,6 @@
             "name": "llvm_mi100_mpi",
             "inherits": ["llvm"],
             "displayName": "LLVM Clang MI100",
-            "binaryDir": "${sourceDir}/build/llvm_mi100",
             "environment": {
                 "PRESET_CXX_FLAGS": "-fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908"
             }
@@ -144,7 +135,6 @@
             "name": "nvhpc_v100",
             "inherits": ["base"],
             "displayName": "NVIDIA NVHPC V100",
-            "binaryDir": "${sourceDir}/build/nvhpc_v100",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "nvc",
                 "CMAKE_CXX_COMPILER": "nvc++"
@@ -157,7 +147,6 @@
             "name": "nvhpc_a100",
             "inherits": ["base"],
             "displayName": "NVIDIA NVHPC A100",
-            "binaryDir": "${sourceDir}/build/nvhpc_a100",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "nvc",
                 "CMAKE_CXX_COMPILER": "nvc++"


### PR DESCRIPTION
When presets were first introduced to CMake in 3.19, each preset required the `binaryDir` variable to be set to a specific build location. This precluded the user from building in an arbitrary directory of their choice. In CMake 3.21 (when version 3 of the preset schema was introduced) they removed this requirement. To allow more build flexibility, and to simplify the preset file, this PR simply removes all the `binaryDir` lines. Once incorporated, I'll have to update our auto testing scripts, but I think it is worthwhile as a user already ran into an issue with this.

This shouldn't cause any increase in the preset file version requirements as we were already using preset schema version 3.