### PR TITLE
Add a static map supporting on-device lookups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,7 @@ list(APPEND libopenmc_SOURCES
   src/simulation.cpp
   src/source.cpp
   src/state_point.cpp
+  src/static_map.cpp
   src/string_utils.cpp
   src/summary.cpp
   src/surface.cpp

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -389,6 +389,12 @@ struct CellInstance {
   bool operator==(const CellInstance& other) const
   { return index_cell == other.index_cell && instance == other.instance; }
 
+  bool operator<(const CellInstance& other) const
+  {
+    return std::tie(index_cell, instance) <
+           std::tie(other.index_cell, other.instance);
+  }
+
   gsl::index index_cell;
   gsl::index instance;
 };

--- a/include/openmc/particle.h
+++ b/include/openmc/particle.h
@@ -49,7 +49,7 @@
 //#define SECONDARY_BANK_SIZE 200 // 100 not enough to pass regression tests, but 200 works. TODO: narrow this down.
 #define SECONDARY_BANK_SIZE 5 // 100 not enough to pass regression tests, but 200 works. TODO: narrow this down.
 #define FLUX_DERIVS_SIZE 1 // This is the min required to pass regression tests (diff_tally is limiter)
-#define FILTER_MATCHES_SIZE 2 // tallies regression test is the limiter here. More realistic tests only need 2. This can be set at runtime init though.
+#define FILTER_MATCHES_SIZE 3 // tallies regression test is the limiter here. More realistic tests only need 2. This can be set at runtime init though.
 //#define FILTER_MATCHES_SIZE 140 // tallies regression test is the limiter here. More realistic tests only need 2. This can be set at runtime init though.
 #define NU_BANK_SIZE 16 // infinite_cell regression test
 

--- a/include/openmc/static_map.h
+++ b/include/openmc/static_map.h
@@ -39,7 +39,8 @@ struct integer_hash
 //! This is a read-only hash table that supports on-device lookups. The table
 //! is constructed on the host and must be "finalized" before it can be used to
 //! search for items. Adapted from the \c Static_Device_Map class in Oak Ridge
-//! National Laboratory's SCALE code system.
+//! National Laboratory's SCALE code system with help from 
+//! Seth Johnson, Tom Evans, and Steven Hamilton.
 template<typename Key, typename T, typename Hash = integer_hash<Key>>
 class static_map {
 public:

--- a/include/openmc/static_map.h
+++ b/include/openmc/static_map.h
@@ -1,0 +1,251 @@
+#ifndef OPENMC_STATIC_MAP_H
+#define OPENMC_STATIC_MAP_H
+
+#include <algorithm> // for stable_sort, find_if, lower_bound
+#include <utility> // for pair
+
+#include "openmc/vector.h"
+
+namespace openmc {
+
+//==========================================================================
+// Integer hash function
+//==========================================================================
+
+//! Hash function for integers that simply returns the integer.
+//
+//! If the values in the hash table are consecutive starting from zero, this
+//! will produce no collisions. Otherwise, all bets are off.
+//
+//! TODO: explore the performance of different hash functions
+template<typename Key>
+struct integer_hash
+{
+  using value_type = Key;
+  using result_type = std::size_t;
+
+  result_type operator()(value_type value) const
+  {
+    return static_cast<result_type>(value);
+  }
+};
+
+//==========================================================================
+// Class declarations
+//==========================================================================
+
+//! Fixed-size map with on-device access.
+//
+//! This is a read-only hash table that supports on-device lookups. The table
+//! is constructed on the host and must be "finalized" before it can be used to
+//! search for items. Adapted from the \c Static_Device_Map class in Oak Ridge
+//! National Laboratory's SCALE code system.
+template<typename Key, typename T, typename Hash = integer_hash<Key>>
+class static_map {
+public:
+  // Types, aliases
+  using key_type = Key;
+  using mapped_type = T;
+  using value_type = std::pair<key_type, mapped_type>;
+  using size_type = std::size_t;
+  using const_iterator = const value_type*;
+
+public:
+  // Host methods
+  bool finalized() const { return finalized_; }
+  void insert(value_type value) { items_.push_back(value); }
+  inline void erase(key_type key);
+  inline void reserve(size_type count);
+  inline void clear();
+  inline void finalize();
+  inline void copy_to_device();
+
+  // Host/device methods
+  bool empty() const { return items_.empty(); }
+  size_type size() const { return items_.size(); }
+  const_iterator begin() const { return items_.begin(); }
+  const_iterator end() const { return items_.end(); }
+  size_type bucket_count() const { return buckets_.size(); }
+  inline size_type bucket_size(size_type idx) const;
+  inline double load_factor() const;
+  inline const T& operator[](key_type key) const;
+  inline const_iterator find(key_type key) const;
+  inline bool exists(key_type key) const;
+
+private:
+  // Data members
+  vector<value_type> items_; //!< Key/value pairs
+  vector<std::pair<size_type, size_type>>
+    buckets_;              //!< Bucket start and end indices
+  bool finalized_ {false}; //!< Whether hash table has been constructed
+  Hash hash_;              //!< Hash function
+
+  // Helper methods
+  size_type bucket_index(const key_type& key) const;
+  size_type calc_num_buckets(size_type count) const;
+
+  // Sorting function for hashes
+  struct HashComparator {
+    const Hash& hash_;
+    const int num_buckets_;
+
+    HashComparator(const Hash& hash, int num_buckets)
+      : hash_(hash), num_buckets_(num_buckets)
+    {}
+
+    bool operator()(const value_type& left, const value_type& right) const
+    {
+      auto lhash = hash_(left.first) % num_buckets_;
+      auto rhash = hash_(right.first) % num_buckets_;
+
+      if (lhash == rhash) {
+        // Sort by key inside the hash
+        return left.first < right.first;
+      }
+      return lhash < rhash;
+    }
+  };
+};
+
+//==========================================================================
+// Inline definitions
+//==========================================================================
+
+template<typename Key, typename T, typename Hash>
+auto static_map<Key, T, Hash>::bucket_size(size_type idx) const -> size_type
+{
+  const auto& bounds = buckets_[idx];
+  return bounds.second - bounds.first;
+}
+
+template<typename Key, typename T, typename Hash>
+double static_map<Key, T, Hash>::load_factor() const
+{
+  return static_cast<double>(this->size()) / this->bucket_count();
+}
+
+template<typename Key, typename T, typename Hash>
+void static_map<Key, T, Hash>::erase(key_type key)
+{
+  // Search for the key
+  auto iter = std::find_if(items_.begin(), items_.end(),
+    [key](const value_type& kv) { return kv.first == key; });
+
+  // Delete the item
+  if (iter != items_.end()) {
+    items_.erase(iter);
+  }
+}
+
+template<typename Key, typename T, typename Hash>
+void static_map<Key, T, Hash>::reserve(size_type count)
+{
+  items_.reserve(count);
+  buckets_.reserve(this->calc_num_buckets(count));
+}
+
+template<typename Key, typename T, typename Hash>
+void static_map<Key, T, Hash>::clear()
+{
+  items_.clear();
+  buckets_.clear();
+}
+
+template<typename Key, typename T, typename Hash>
+void static_map<Key, T, Hash>::finalize()
+{
+  // Empty map: nothing to do
+  if (this->empty()) {
+    finalized_ = true;
+    return;
+  }
+
+  // Create empty buckets (begin == end)
+  buckets_.resize(this->calc_num_buckets(this->size()), {0, 0});
+
+  // Sort the key/value pairs according to hash, preserving the relative order
+  // of duplicate items. This ensures that if elements with identical keys
+  // exist, the first one inserted will be found. Note, however, that duplicates
+  // are *not* removed from the vector -- it is up to the caller to avoid
+  // inserting them unnecessarily.
+  std::stable_sort(
+    items_.begin(), items_.end(), HashComparator(hash_, this->bucket_count()));
+
+  // Put the key/value pairs into consecutive buckets according to hash,
+  // while checking for uniqueness by comparing against previous key
+  auto prev_hash = this->bucket_index(items_.front().first);
+  for (auto i = 1; i < this->size(); ++i) {
+    const auto& key = items_[i].first;
+    const auto hash = this->bucket_index(key);
+    if (hash == prev_hash) {
+      continue;
+    }
+
+    // If the hash is different, the last bucket has ended and the next
+    // bucket has begun
+    buckets_[prev_hash].second = i;
+    buckets_[hash].first = i;
+    prev_hash = hash;
+  }
+  // Add the final bucket 'end' index
+  buckets_[prev_hash].second = this->size();
+  finalized_ = true;
+}
+
+template<typename Key, typename T, typename Hash>
+void static_map<Key, T, Hash>::copy_to_device()
+{
+    items_.copy_to_device();
+    buckets_.copy_to_device();
+}
+
+template<typename Key, typename T, typename Hash>
+const T& static_map<Key, T, Hash>::operator[](key_type key) const
+{
+  // Map must be finalized and key *must* exist in the map; for efficiency no
+  // search is performed to see if the key has been inserted
+  auto idx = this->bucket_index(key);
+  const_iterator iter = items_.begin() + buckets_[idx].first;
+  do {
+    if (key == iter->first) {
+      return iter->second;
+    }
+    ++iter;
+  } while (true);
+}
+
+template<typename Key, typename T, typename Hash>
+typename static_map<Key, T, Hash>::const_iterator
+static_map<Key, T, Hash>::find(key_type key) const
+{
+  // Map must be finalized first!
+  auto idx = this->bucket_index(key);
+  const auto bounds = buckets_[idx];
+
+  const auto last = items_.begin() + bounds.second;
+  for (auto iter = items_.begin() + bounds.first; iter != last; ++iter) {
+    if (key == iter->first) {
+      return iter;
+    }
+  }
+  // Not found
+  return items_.end();
+}
+
+template<typename Key, typename T, typename Hash>
+bool static_map<Key, T, Hash>::exists(key_type key) const
+{
+  // Map must be finalized first!
+  return this->find(key) != items_.end();
+}
+
+template<typename Key, typename T, typename Hash>
+auto static_map<Key, T, Hash>::bucket_index(const key_type& key) const
+  -> size_type
+{
+  return hash_(key) % this->bucket_count();
+}
+
+} // namespace openmc
+
+#endif

--- a/include/openmc/tallies/filter.h
+++ b/include/openmc/tallies/filter.h
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include <gsl/gsl>
@@ -15,6 +14,7 @@
 #include "openmc/hdf5_interface.h"
 #include "openmc/mesh.h"
 #include "openmc/particle.h"
+#include "openmc/static_map.h"
 #include "openmc/tallies/filter_match.h"
 #include "pugixml.hpp"
 
@@ -306,9 +306,9 @@ private:
   gsl::index index_;
   vector<double> bins_;
   vector<int32_t> cells_;
-  std::unordered_map<int32_t, int> map_;
+  static_map<int32_t, int> map_;
   vector<CellInstance> cell_instances_;
-  std::unordered_map<CellInstance, gsl::index, CellInstanceHash> imap_;
+  static_map<CellInstance, gsl::index, CellInstanceHash> imap_;
   vector<int> groups_;
   int32_t cell_;
   bool matches_transport_groups_ {false};

--- a/src/static_map.cpp
+++ b/src/static_map.cpp
@@ -1,0 +1,25 @@
+#include "openmc/static_map.h"
+
+namespace openmc {
+
+//==============================================================================
+// Static map implementation
+//==============================================================================
+
+//! Find the nearest prime above a value, used for hash table bucket sizing
+template<typename Key, typename T, typename Hash>
+auto static_map<Key, T, Hash>::calc_num_buckets(size_type count) const
+  -> size_type
+{
+  // Table of largest prime <= 2^n is pulled from https://oeis.org/A014234
+  static const size_type primes[] = {3, 7, 13, 31, 61, 127, 251, 509, 1021,
+    2039, 4093, 8191, 16381, 32749, 65521, 131071, 262139, 524287, 1048573,
+    2097143, 4194301, 8388593, 16777213, 33554393, 67108859, 134217689,
+    268435399, 536870909, 1073741789, 2147483647};
+
+  // Find the first prime number larger than count in the table
+  auto iter = std::lower_bound(std::begin(primes), std::end(primes), count);
+  return *iter;
+}
+
+} // namespace openmc

--- a/src/tallies/filter.cpp
+++ b/src/tallies/filter.cpp
@@ -42,10 +42,8 @@ extern "C" size_t tally_filters_size()
 
 void Filter::copy_to_device()
 {
-  //TODO: Need to Map the unordered map fields to device
-  //map_.copy_to_device();
-  //imap_.copy_to_device();
-
+  map_.copy_to_device();
+  imap_.copy_to_device();
   bins_.copy_to_device();
   cells_.copy_to_device();
   cell_instances_.copy_to_device();

--- a/src/tallies/filter_cell.cpp
+++ b/src/tallies/filter_cell.cpp
@@ -39,9 +39,10 @@ Filter::set_cells(gsl::span<int32_t> cells)
     Expects(index >= 0);
     Expects(index < model::cells.size());
     cells_.push_back(index);
-    map_[index] = cells_.size() - 1;
+    map_.insert({index, cells_.size() - 1});
   }
 
+  map_.finalize();
   n_bins_ = cells_.size();
 }
 

--- a/src/tallies/filter_cell_instance.cpp
+++ b/src/tallies/filter_cell_instance.cpp
@@ -61,9 +61,10 @@ Filter::set_cell_instances(gsl::span<CellInstance> instances)
         "used in a cell instance filter.", c.id_)};
     }
     cell_instances_.push_back(x);
-    imap_[x] = cell_instances_.size() - 1;
+    imap_.insert({x, cell_instances_.size() - 1});
   }
 
+  imap_.finalize();
   n_bins_ = cell_instances_.size();
 }
 

--- a/src/tallies/filter_material.cpp
+++ b/src/tallies/filter_material.cpp
@@ -38,9 +38,10 @@ Filter::set_materials(gsl::span<const int32_t> materials)
     Expects(index >= 0);
     Expects(index < model::materials_size);
     materials_.push_back(index);
-    map_[index] = materials_.size() - 1;
+    map_.insert({index, materials_.size() - 1});
   }
 
+  map_.finalize();
   n_bins_ = materials_.size();
 }
 

--- a/src/tallies/filter_surface.cpp
+++ b/src/tallies/filter_surface.cpp
@@ -40,9 +40,10 @@ Filter::set_surfaces(gsl::span<int32_t> surfaces)
     Expects(index >= 0);
     Expects(index < model::surfaces.size());
     surfaces_.push_back(index);
-    map_[index] = surfaces_.size() - 1;
+    map_.insert({index, surfaces_.size() - 1});
   }
 
+  map_.finalize();
   n_bins_ = surfaces_.size();
 }
 

--- a/src/tallies/filter_universe.cpp
+++ b/src/tallies/filter_universe.cpp
@@ -38,9 +38,10 @@ Filter::set_universes(gsl::span<int32_t> universes)
     Expects(index >= 0);
     Expects(index < model::universes.size());
     universes_.push_back(index);
-    map_[index] = universes_.size() - 1;
+    map_.insert({index, universes_.size() - 1});
   }
 
+  map_.finalize();
   n_bins_ = universes_.size();
 }
 


### PR DESCRIPTION
This adds a simple read-only map that can be used for on-device lookups and uses it instead of `std::unordered_map` in the tally filters. I tested it out on an A100 with a simple problem using a material filter and everything seemed to work. Since tallying is currently done on the host, I also did some additional (hacky) testing to make sure the map is working as expected on device. None of our current offloading benchmark problems have filters that use maps, so I can add a model to the repo where a map is actually used during tallying.