### PR TITLE
SMR-Oriented Optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,8 +132,8 @@ if(coverage)
   list(APPEND ldflags --coverage)
 endif()
 if(sycl_sort)
-  list(APPEND cxxflags -fsycl -D_GLIBCXX_USE_TBB_PAR_BACKEND=0)
-  list(APPEND ldflags -fsycl -D_GLIBCXX_USE_TBB_PAR_BACKEND=0)
+  list(APPEND cxxflags -fsycl -D_PSTL_PAR_BACKEND_SERIAL=1 -DPSTL_USE_PARALLEL_POLICIES=0 -D_GLIBCXX_USE_TBB_PAR_BACKEND=0)
+  list(APPEND ldflags -fsycl -D_PSTL_PAR_BACKEND_SERIAL=1 -DPSTL_USE_PARALLEL_POLICIES=0 -D_GLIBCXX_USE_TBB_PAR_BACKEND=0)
 endif()
 
 # Show flags being used
@@ -173,7 +173,7 @@ endif()
 
 if (NOT pugixml_FOUND)
   add_subdirectory(vendor/pugixml)
-  set_target_properties(pugixml PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
+  set_target_properties(pugixml PROPERTIES CXX_STANDARD 17 CXX_EXTENSIONS OFF)
 endif()
 
 #===============================================================================
@@ -469,7 +469,7 @@ target_link_libraries(openmc libopenmc)
 set_target_properties(
   #openmc libopenmc faddeeva
     openmc libopenmc
-    PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
+    PROPERTIES CXX_STANDARD 17 CXX_EXTENSIONS OFF)
 
 #===============================================================================
 # Python package

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,8 +24,8 @@
             "name": "intel",
             "inherits": ["unity"],
             "cacheVariables": {
-                "CMAKE_C_COMPILER": "icx",
-                "CMAKE_CXX_COMPILER": "icpx"
+                "CMAKE_C_COMPILER": "mpicc",
+                "CMAKE_CXX_COMPILER": "mpiicpx"
             },
             "environment": {
                 "INTEL_CXX_FLAGS": "-fiopenmp"
@@ -66,7 +66,15 @@
             "inherits": ["intel"],
             "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
             "environment": {
-                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device 12.60.7 -internal_options -ze-opt-large-register-file\" -mllvm -vpo-paropt-atomic-free-reduction=false -mllvm -indvars-widen-indvars=false"
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device 12.60.7 -internal_options -ze-opt-large-register-file\" -mllvm -vpo-paropt-atomic-free-reduction=false -mllvm -indvars-widen-indvars=false -DREDUCTION_WORKAROUND"
+            }
+        },
+        {
+            "name": "spirv_jit_pvc",
+            "inherits": ["intel"],
+            "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
+            "environment": {
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64 -mllvm -indvars-widen-indvars=false"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,6 +32,17 @@
             }
         },
         {
+            "name": "gcc_host",
+            "inherits": ["base"],
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++"
+            },
+            "environment": {
+                "LLVM_CXX_FLAGS": "-fopenmp"
+            }
+        },
+        {
             "name": "llvm",
             "inherits": ["unity"],
             "cacheVariables": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,11 +51,19 @@
             }
         },
         {
-            "name": "spirv_aot",
+            "name": "spirv_aot_pvc",
             "inherits": ["intel"],
             "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
             "environment": {
-                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device xehp -revision_id 4 -internal_options -ze-opt-large-register-file\" -mllvm -vpo-paropt-atomic-free-reduction=false"
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device 12.60.7 -internal_options -ze-opt-large-register-file\" -mllvm -vpo-paropt-atomic-free-reduction=false -mllvm -indvars-widen-indvars=false"
+            }
+        },
+        {
+            "name": "spirv_aot_ats",
+            "inherits": ["intel"],
+            "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
+            "environment": {
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device 12.50.4 -internal_options -ze-opt-large-register-file\" -mllvm -vpo-paropt-atomic-free-reduction=false -mllvm -indvars-widen-indvars=false"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,27 +62,19 @@
             }
         },
         {
+            "name": "spirv_jit",
+            "inherits": ["intel"],
+            "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
+            "environment": {
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64 -mllvm -indvars-widen-indvars=false -DREDUCTION_WORKAROUND"
+            }
+        },
+        {
             "name": "spirv_aot_pvc",
             "inherits": ["intel"],
             "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
             "environment": {
-                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device 12.60.7 -internal_options -ze-opt-large-register-file\" -mllvm -vpo-paropt-atomic-free-reduction=false -mllvm -indvars-widen-indvars=false -DREDUCTION_WORKAROUND"
-            }
-        },
-        {
-            "name": "spirv_jit_pvc",
-            "inherits": ["intel"],
-            "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
-            "environment": {
-                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64 -mllvm -indvars-widen-indvars=false"
-            }
-        },
-        {
-            "name": "spirv_aot_pvc_no_atomic",
-            "inherits": ["intel"],
-            "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
-            "environment": {
-                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device 12.60.7 -internal_options -ze-opt-large-register-file\" -mllvm -indvars-widen-indvars=false"
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device 12.60.7 -internal_options -ze-opt-large-register-file\" -mllvm -vpo-paropt-atomic-free-reduction=false -mllvm -indvars-widen-indvars=false"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -58,7 +58,7 @@
             "inherits": ["intel"],
             "displayName": "Intel GPUs",
             "environment": {
-                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64 -mllvm -vpo-paropt-atomic-free-reduction=false"
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64"
             }
         },
         {
@@ -67,6 +67,14 @@
             "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
             "environment": {
                 "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device 12.60.7 -internal_options -ze-opt-large-register-file\" -mllvm -vpo-paropt-atomic-free-reduction=false -mllvm -indvars-widen-indvars=false"
+            }
+        },
+        {
+            "name": "spirv_aot_pvc_no_atomic",
+            "inherits": ["intel"],
+            "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
+            "environment": {
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device 12.60.7 -internal_options -ze-opt-large-register-file\" -mllvm -indvars-widen-indvars=false"
             }
         },
         {

--- a/include/openmc/event.h
+++ b/include/openmc/event.h
@@ -24,15 +24,15 @@ namespace openmc {
 struct EventQueueItem{
   int idx;         //!< particle index in event-based particle buffer
   //Particle::Type type; //!< particle type
-  //int64_t material;    //!< material that particle is in
+  int material;    //!< material that particle is in
   //double E;            //!< particle energy
   float E;            //!< particle energy
   //int64_t id;
 
   // Constructors
   EventQueueItem() = default;
-  EventQueueItem(double energy, int buffer_idx) :
-    idx(buffer_idx), E(static_cast<float>(energy)) {}
+  EventQueueItem(double energy, int mat, int buffer_idx) :
+    idx(buffer_idx), material(mat), E(static_cast<float>(energy)) {}
 
   // Compare by particle type, then by material type (4.5% fuel/7.0% fuel/cladding/etc),
   // then by energy.
@@ -47,14 +47,22 @@ struct EventQueueItem{
   bool operator<(const EventQueueItem& rhs) const
   {
     //return std::tie(type, material, E) < std::tie(rhs.type, rhs.material, rhs.E);
-    return E < rhs.E;
+    //return E < rhs.E;
+    if (material == rhs.material)
+      return E < rhs.E;
+    else
+      return material < rhs.material;
   }
   
   // This is needed by the implementation of parallel quicksort
   bool operator>(const EventQueueItem& rhs) const
   {
     //return std::tie(type, material, E) < std::tie(rhs.type, rhs.material, rhs.E);
-    return E > rhs.E;
+    //return E > rhs.E;
+    if (material == rhs.material)
+      return E > rhs.E;
+    else
+      return material > rhs.material;
   }
 };
 

--- a/include/openmc/event.h
+++ b/include/openmc/event.h
@@ -85,6 +85,19 @@ extern int current_source_offset;
 
 extern int sort_counter;
 
+extern int e_fuel;
+extern int e_nonfuel;
+extern int e_advance;
+extern int e_surface;
+extern int e_collision;
+extern int e_revival;
+extern int64_t ep_fuel;
+extern int64_t ep_nonfuel;
+extern int64_t ep_advance;
+extern int64_t ep_surface;
+extern int64_t ep_collision;
+extern int64_t ep_revival;
+
 } // namespace simulation
 
 //==============================================================================

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -60,7 +60,8 @@ public:
   // Methods
 
   #pragma omp declare target
-  void calculate_xs(Particle& p, bool need_depletion_rx) const;
+  void calculate_xs(Particle& p) const;
+  void calculate_xs_no_depletion(Particle& p) const;
   #pragma omp end declare target
 
   //! Assign thermal scattering tables to specific nuclides within the material
@@ -197,7 +198,8 @@ private:
   void normalize_density();
 
   #pragma omp declare target
-  void calculate_neutron_xs(Particle& p, bool need_depletion_rx) const;
+  void calculate_neutron_xs(Particle& p) const;
+  void calculate_neutron_xs_no_depletion(Particle& p) const;
   void calculate_photon_xs(Particle& p) const;
   #pragma omp end declare target
 

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -37,18 +37,12 @@ extern std::unordered_map<int32_t, int32_t> material_map;
 #pragma omp declare target
 extern Material* materials;
 extern uint64_t materials_size;
-extern int     serial_materials_size;
-extern int     serial_materials_offset;
-extern int     serial_materials_element_size;
-extern int     serial_materials_element_offset;
-extern int     serial_materials_thermal_tables_size;
-extern int     serial_materials_thermal_tables_offset;
-extern int* serial_materials_nuclide;
-extern int* serial_materials_element;
-extern int* serial_materials_p0;
-extern int* serial_materials_mat_nuclide_index;
-extern ThermalTable* serial_materials_thermal_tables;
-extern double* serial_materials_atom_density;
+extern vector2d<int> materials_nuclide;
+extern vector2d<int> materials_element;
+extern vector2d<double> materials_atom_density;
+extern vector2d<int> materials_p0;
+extern vector2d<int> materials_mat_nuclide_index;
+extern vector2d<ThermalTable> materials_thermal_tables;
 #pragma omp end declare target
 
 } // namespace model
@@ -167,19 +161,12 @@ public:
   void release_from_device();
 
   #pragma omp declare target
-  int& nuclide(int i) {                 return model::serial_materials_nuclide[          index_ * model::serial_materials_offset + i]; }
-  int& element(int i) {                 return model::serial_materials_element[          index_ * model::serial_materials_element_offset + i]; }
-  double& atom_density(int i) {         return model::serial_materials_atom_density[     index_ * model::serial_materials_offset + i]; }
-  int& p0(int i) {                      return model::serial_materials_p0[               index_ * model::serial_materials_offset + i]; }
-  int& mat_nuclide_index(int i) {       return model::serial_materials_mat_nuclide_index[index_ * model::serial_materials_offset + i]; }
-  ThermalTable& thermal_tables(int i) { return model::serial_materials_thermal_tables[   index_ * model::serial_materials_thermal_tables_offset + i]; }
-  
-  int& nuclide(int i) const {                 return model::serial_materials_nuclide[          index_ * model::serial_materials_offset + i]; }
-  int& element(int i) const {                 return model::serial_materials_element[          index_ * model::serial_materials_element_offset + i]; }
-  double& atom_density(int i) const {         return model::serial_materials_atom_density[     index_ * model::serial_materials_offset + i]; }
-  int& p0(int i) const {                      return model::serial_materials_p0[               index_ * model::serial_materials_offset + i]; }
-  int& mat_nuclide_index(int i)const  {       return model::serial_materials_mat_nuclide_index[index_ * model::serial_materials_offset + i]; }
-  ThermalTable& thermal_tables(int i) const { return model::serial_materials_thermal_tables[   index_ * model::serial_materials_thermal_tables_offset + i]; }
+  int& nuclide(int i) const {                 return model::materials_nuclide(          index_, i);}
+  int& element(int i) const {                 return model::materials_element(          index_, i);}
+  double& atom_density(int i) const {         return model::materials_atom_density(     index_, i);}
+  int& p0(int i) const {                      return model::materials_p0(               index_, i);}
+  int& mat_nuclide_index(int i)const  {       return model::materials_mat_nuclide_index(index_, i);}
+  ThermalTable& thermal_tables(int i) const { return model::materials_thermal_tables(   index_, i);}
   #pragma omp end declare target
 
   uint64_t calculate_footprint()

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -55,16 +55,6 @@ class Material
 {
 public:
   //----------------------------------------------------------------------------
-  // Types
-  /*
-  struct ThermalTable {
-    int index_table; //!< Index of table in data::thermal_scatt
-    int index_nuclide; //!< Index in nuclide_
-    double fraction; //!< How often to use table
-  };
-  */
-
-  //----------------------------------------------------------------------------
   // Constructors, destructors, factory functions
   Material() {};
   explicit Material(pugi::xml_node material_node);
@@ -169,18 +159,6 @@ public:
   ThermalTable& thermal_tables(int i) const { return model::materials_thermal_tables(   index_, i);}
   #pragma omp end declare target
 
-  uint64_t calculate_footprint()
-  {
-    uint64_t n = 0;
-    //n += nuclide_.size() * sizeof(int);
-    //n += element_.size() * sizeof(int);
-    //n += mat_nuclide_index_.size() * sizeof(int);
-    //n += p0_.size() * sizeof(int);
-    //n += atom_density_.size() * sizeof(double);
-    //n += thermal_tables_.size() * sizeof(ThermalTable);
-    return n;
-  }
-
   //----------------------------------------------------------------------------
   // Data
   int32_t id_ {C_NONE}; //!< Unique ID
@@ -188,7 +166,6 @@ public:
   vector<int> nuclide_; //!< Indices in nuclides vector
   vector<int> element_; //!< Indices in elements vector
   xt::xtensor<double, 1> atom_density_; //!< Nuclide atom density in [atom/b-cm]
-  double* device_atom_density_;
   double density_; //!< Total atom density in [atom/b-cm]
   double density_gpcc_; //!< Total atom density in [g/cm^3]
   double volume_ {-1.0}; //!< Volume in [cm^3]
@@ -229,7 +206,6 @@ private:
 
   //----------------------------------------------------------------------------
   // Private data members
-  //gsl::index index_;
 
   //! \brief Default temperature for cells containing this material.
   //!

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -145,6 +145,18 @@ public:
   void copy_to_device();
   void release_from_device();
 
+  uint64_t calculate_footprint()
+  {
+    uint64_t n = 0;
+    n += nuclide_.size() * sizeof(int);
+    n += element_.size() * sizeof(int);
+    n += mat_nuclide_index_.size() * sizeof(int);
+    n += p0_.size() * sizeof(int);
+    n += atom_density_.size() * sizeof(double);
+    n += thermal_tables_.size() * sizeof(ThermalTable);
+    return n;
+  }
+
   //----------------------------------------------------------------------------
   // Data
   int32_t id_ {C_NONE}; //!< Unique ID

--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -46,6 +46,7 @@ public:
 
   #pragma omp declare target
   NuclideMicroXS calculate_xs(int i_log_union, Particle& p, bool need_depletion_rx);
+  MicroXS calculate_xs_no_depletion(int i_log_union, Particle& p);
 
   // Methods
   double nu(double E, EmissionMode mode, int group=0) const;

--- a/include/openmc/particle.h
+++ b/include/openmc/particle.h
@@ -353,7 +353,8 @@ public:
   void event_tracklength_tally(bool need_depletion_rx);
   void event_calculate_xs(bool need_depletion_rx);
   bool event_calculate_xs_dispatch();
-  void event_calculate_xs_execute(bool need_depletion_rx);
+  void event_calculate_xs_execute();
+  void event_calculate_xs_execute_no_depletion();
   void event_collide();
   void event_advance();
   void event_cross_surface();

--- a/include/openmc/particle.h
+++ b/include/openmc/particle.h
@@ -134,6 +134,35 @@ struct NuclideMicroXS {
                             //!< * temperature (eV))
 };
 
+struct NuclideMicroXSNoDepletion {
+  // Microscopic cross sections in barns
+  double total;            //!< total cross section
+  double absorption;       //!< absorption (disappearance)
+  double fission;          //!< fission
+  double nu_fission;       //!< neutron production from fission
+
+  double elastic;          //!< If sab_frac is not 1 or 0, then this value is
+                           //!<   averaged over bound and non-bound nuclei
+  double thermal;          //!< Bound thermal elastic & inelastic scattering
+  double thermal_elastic;  //!< Bound thermal elastic scattering
+  double photon_prod;      //!< microscopic photon production xs
+
+  // Indicies and factors needed to compute cross sections from the data tables
+  int index_grid;        //!< Index on nuclide energy grid
+  int index_temp;        //!< Temperature index for nuclide
+  double interp_factor;  //!< Interpolation factor on nuc. energy grid
+  int index_sab {-1};    //!< Index in sab_tables
+  int index_temp_sab;    //!< Temperature index for sab_tables
+  double sab_frac;       //!< Fraction of atoms affected by S(a,b)
+  bool use_ptable;       //!< In URR range with probability tables?
+
+  // Energy and temperature last used to evaluate these cross sections.  If
+  // these values have changed, then the cross sections must be re-evaluated.
+  double last_E {0.0};      //!< Last evaluated energy
+  double last_sqrtkT {0.0}; //!< Last temperature in sqrt(Boltzmann constant
+                            //!< * temperature (eV))
+};
+
 class NuclideMicroXSCache {
   public:
   NuclideMicroXS neutron_xs_[NEUTRON_XS_SIZE]; //!< Microscopic neutron cross sections

--- a/include/openmc/simulation.h
+++ b/include/openmc/simulation.h
@@ -63,6 +63,8 @@ extern std::vector<Particle>  particles;
 extern Particle* device_particles;
 #pragma omp end declare target
 
+extern int n_events;
+extern long n_work;
 
 } // namespace simulation
 

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -135,10 +135,6 @@ public:
 
   int deriv_ {C_NONE}; //!< Index of a TallyDerivative object for diff tallies.
 
-private:
-  //----------------------------------------------------------------------------
-  // Private data.
-
   vector<int32_t> filters_; //!< Filter indices in global filters array
 
   //! Index strides assigned to each filter to support 1D indexing.

--- a/include/openmc/vector.h
+++ b/include/openmc/vector.h
@@ -397,6 +397,7 @@ public:
   using reference = T&;
   using const_reference = const T&;
   using vector<T>::data_;
+  using vector<T>::capacity_;
   using vector<T>::size_;
   // Constructors, destructors
   vector2d() :  offset_(0), vector<T>() { }
@@ -406,16 +407,18 @@ public:
   // TODO: If you have a global variable that is of type vector<T>, its
   // destructor gets called which then requires ~T() to be available on device.
   // Figure out a way around this
+  /*
   ~vector2d() {
     if (data_) {
       if (omp_is_initial_device()) {
-        this->clear();
-        std::free(data_);
+        //this->clear();
+        //std::free(data_);
       } else {
 //#pragma omp target exit data map(delete: data_)
       }
     }
   }
+  */
   reference operator()(size_type outer_pos, size_type pos) { return data_[outer_pos * offset_ + pos]; }
   const_reference operator()(size_type outer_pos, size_type pos) const { return data_[outer_pos * offset_ + pos]; }
   void stretch(vector<T>& vect) {
@@ -453,6 +456,9 @@ public:
     for (int j = 0; j < vect.size(); j++) {
       data_[i * offset_ + j] = vect[j];
     }
+  }
+  void print_stats() {
+    std::cout << "(size, capacity, offset, pointer) = (" << size_ << ", " << capacity_ << ", " << offset_ << ", " << data_ << ")" << std::endl;
   }
   size_type offset_;
 };

--- a/src/bremsstrahlung.cpp
+++ b/src/bremsstrahlung.cpp
@@ -33,9 +33,11 @@ void BremsstrahlungData::copy_to_device()
   device_pdf_ = pdf_.data();
   device_cdf_ = cdf_.data();
   device_yield_ = yield_.data();
-  #pragma omp target enter data map(to: device_pdf_[:pdf_.size()])
-  #pragma omp target enter data map(to: device_cdf_[:cdf_.size()])
-  #pragma omp target enter data map(to: device_yield_[:yield_.size()])
+  if (pdf_.size() > 0 ) {
+    #pragma omp target enter data map(to: device_pdf_[:pdf_.size()])
+    #pragma omp target enter data map(to: device_cdf_[:cdf_.size()])
+    #pragma omp target enter data map(to: device_yield_[:yield_.size()])
+  }
 }
 
 void BremsstrahlungData::release_from_device()

--- a/src/device_alloc.cpp
+++ b/src/device_alloc.cpp
@@ -184,7 +184,12 @@ void move_read_only_data_to_device()
 
   // Materials /////////////////////////////////////////////////////////
 
-  std::cout << "Moving " << model::materials_size << " materials to device..." << std::endl;
+  int n_bytes = model::materials_size * sizeof(Material);
+  for (int i = 0; i < model::materials_size; i++) {
+    n_bytes += model::materials[i].calculate_footprint();
+  }
+
+  std::cout << "Moving " << model::materials_size << " materials to device of total size: " << n_bytes * 1e-6 << " MB" << std::endl;
   int min = 99999;
   int max = 0;
   int n_over_200 = 0;

--- a/src/device_alloc.cpp
+++ b/src/device_alloc.cpp
@@ -247,6 +247,14 @@ void move_read_only_data_to_device()
     model::materials_mat_nuclide_index.copy_row(i, mat.mat_nuclide_index_);
     model::materials_thermal_tables.copy_row(i, mat.thermal_tables_);
   }
+  
+  // Update top level global fields to device (e.g., size_, capacity_, etc)
+  #pragma omp target update to(model::materials_nuclide)
+  #pragma omp target update to(model::materials_element)
+  #pragma omp target update to(model::materials_atom_density)
+  #pragma omp target update to(model::materials_p0)
+  #pragma omp target update to(model::materials_mat_nuclide_index)
+  #pragma omp target update to(model::materials_thermal_tables)
 
   // Map serialized material vectors to device
   model::materials_nuclide.copy_to_device();
@@ -255,6 +263,7 @@ void move_read_only_data_to_device()
   model::materials_p0.copy_to_device();
   model::materials_mat_nuclide_index.copy_to_device();
   model::materials_thermal_tables.copy_to_device();
+
 
   /*
   // Prepare serial materials

--- a/src/device_alloc.cpp
+++ b/src/device_alloc.cpp
@@ -217,6 +217,46 @@ void move_read_only_data_to_device()
   " # Fissionable Materials with >= 200 Nuclides: " << n_over_200 << std::endl <<
   " # Fissionable Materials with  < 200 Nuclides: " << n_under_200 << std::endl;
 
+
+  // Determine size of inner dimension for serialized material vectors
+  for (int i = 0; i < model::materials_size; i++) {
+    auto& mat = model::materials[i];
+    model::materials_nuclide.stretch(mat.nuclide_);
+    model::materials_element.stretch(mat.element_);
+    model::materials_atom_density.stretch(mat.atom_density_);
+    model::materials_p0.stretch(mat.p0_);
+    model::materials_mat_nuclide_index.stretch(mat.mat_nuclide_index_);
+    model::materials_thermal_tables.stretch(mat.thermal_tables_);
+  }
+  
+  // Allocate serialized material vectors
+  model::materials_nuclide.resize2d(model::materials_size);
+  model::materials_element.resize2d(model::materials_size);
+  model::materials_atom_density.resize2d(model::materials_size);
+  model::materials_p0.resize2d(model::materials_size);
+  model::materials_mat_nuclide_index.resize2d(model::materials_size);
+  model::materials_thermal_tables.resize2d(model::materials_size);
+  
+  // Populate serialized material vectors
+  for (int i = 0; i < model::materials_size; i++) {
+    auto& mat = model::materials[i];
+    model::materials_nuclide.copy_row(i, mat.nuclide_);
+    model::materials_element.copy_row(i, mat.element_);
+    model::materials_atom_density.copy_row(i, mat.atom_density_);
+    model::materials_p0.copy_row(i, mat.p0_);
+    model::materials_mat_nuclide_index.copy_row(i, mat.mat_nuclide_index_);
+    model::materials_thermal_tables.copy_row(i, mat.thermal_tables_);
+  }
+
+  // Map serialized material vectors to device
+  model::materials_nuclide.copy_to_device();
+  model::materials_element.copy_to_device();
+  model::materials_atom_density.copy_to_device();
+  model::materials_p0.copy_to_device();
+  model::materials_mat_nuclide_index.copy_to_device();
+  model::materials_thermal_tables.copy_to_device();
+
+  /*
   // Prepare serial materials
   int max_nuclides = 0;
   int max_elements = 0;
@@ -284,6 +324,7 @@ void move_read_only_data_to_device()
   if (model::serial_materials_thermal_tables_size > 0) {
     #pragma omp target enter data map(to: model::serial_materials_thermal_tables[:model::serial_materials_thermal_tables_size])
   }
+  */
 
   // Source Bank ///////////////////////////////////////////////////////
 

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -183,12 +183,22 @@ void process_calculate_xs_events_nonfuel()
 
   int offset = simulation::advance_particle_queue.size();;
 
-  #pragma omp target teams distribute parallel for
-  for (int i = 0; i < simulation::calculate_nonfuel_xs_queue.size(); i++) {
-    int buffer_idx = simulation::calculate_nonfuel_xs_queue[i].idx;
-    Particle& p = simulation::device_particles[buffer_idx];
-    p.event_calculate_xs_execute(need_depletion_rx);
-    simulation::advance_particle_queue[offset + i] = simulation::calculate_nonfuel_xs_queue[i];
+  if (need_depletion_rx) {
+    #pragma omp target teams distribute parallel for
+    for (int i = 0; i < simulation::calculate_nonfuel_xs_queue.size(); i++) {
+      int buffer_idx = simulation::calculate_nonfuel_xs_queue[i].idx;
+      Particle& p = simulation::device_particles[buffer_idx];
+      p.event_calculate_xs_execute();
+      simulation::advance_particle_queue[offset + i] = simulation::calculate_nonfuel_xs_queue[i];
+    }
+  } else {
+    #pragma omp target teams distribute parallel for
+    for (int i = 0; i < simulation::calculate_nonfuel_xs_queue.size(); i++) {
+      int buffer_idx = simulation::calculate_nonfuel_xs_queue[i].idx;
+      Particle& p = simulation::device_particles[buffer_idx];
+      p.event_calculate_xs_execute_no_depletion();
+      simulation::advance_particle_queue[offset + i] = simulation::calculate_nonfuel_xs_queue[i];
+    }
   }
 
   // After executing a calculate_xs event, particles will
@@ -217,12 +227,22 @@ void process_calculate_xs_events_fuel()
 
   int offset = simulation::advance_particle_queue.size();;
 
-  #pragma omp target teams distribute parallel for
-  for (int i = 0; i < simulation::calculate_fuel_xs_queue.size(); i++) {
-    int buffer_idx = simulation::calculate_fuel_xs_queue[i].idx;
-    Particle& p = simulation::device_particles[buffer_idx];
-    p.event_calculate_xs_execute(need_depletion_rx);
-    simulation::advance_particle_queue[offset + i] = simulation::calculate_fuel_xs_queue[i];
+  if (need_depletion_rx) {
+    #pragma omp target teams distribute parallel for
+    for (int i = 0; i < simulation::calculate_fuel_xs_queue.size(); i++) {
+      int buffer_idx = simulation::calculate_fuel_xs_queue[i].idx;
+      Particle& p = simulation::device_particles[buffer_idx];
+      p.event_calculate_xs_execute();
+      simulation::advance_particle_queue[offset + i] = simulation::calculate_fuel_xs_queue[i];
+    }
+  } else {
+    #pragma omp target teams distribute parallel for
+    for (int i = 0; i < simulation::calculate_fuel_xs_queue.size(); i++) {
+      int buffer_idx = simulation::calculate_fuel_xs_queue[i].idx;
+      Particle& p = simulation::device_particles[buffer_idx];
+      p.event_calculate_xs_execute_no_depletion();
+      simulation::advance_particle_queue[offset + i] = simulation::calculate_fuel_xs_queue[i];
+    }
   }
 
   // After executing a calculate_xs event, particles will

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -213,13 +213,14 @@ void process_calculate_xs_events_nonfuel()
 {
   simulation::e_nonfuel++;
   simulation::ep_nonfuel += simulation::calculate_nonfuel_xs_queue.size();
-  simulation::time_event_calculate_xs.start();
-  simulation::time_event_calculate_xs_nonfuel.start();
 
   bool need_depletion_rx = depletion_rx_check();
 
   int offset = simulation::advance_particle_queue.size();;
   sort_queue(simulation::calculate_nonfuel_xs_queue);
+  
+  simulation::time_event_calculate_xs.start();
+  simulation::time_event_calculate_xs_nonfuel.start();
 
   if (need_depletion_rx) {
     #pragma omp target teams distribute parallel for

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -140,13 +140,13 @@ void dispatch_xs_event(int buffer_idx)
   if (needs_lookup) {
     // If a lookup is needed, dispatch to fuel vs. non-fuel lookup queue
     if (!model::materials[p.material_].fissionable_) {
-      simulation::calculate_nonfuel_xs_queue.thread_safe_append({p.E_, buffer_idx});
+      simulation::calculate_nonfuel_xs_queue.thread_safe_append({p.E_, p.material_, buffer_idx});
     } else {
-      simulation::calculate_fuel_xs_queue.thread_safe_append({p.E_, buffer_idx});
+      simulation::calculate_fuel_xs_queue.thread_safe_append({p.E_, -1, buffer_idx});
     }
   } else {
     // Otherwise, particle can move directly to the advance particle queue
-    simulation::advance_particle_queue.thread_safe_append({p.E_, buffer_idx});
+    simulation::advance_particle_queue.thread_safe_append({p.E_, p.material_, buffer_idx});
   }
 }
 
@@ -198,6 +198,7 @@ void process_calculate_xs_events_nonfuel()
   bool need_depletion_rx = depletion_rx_check();
 
   int offset = simulation::advance_particle_queue.size();;
+  sort_queue(simulation::calculate_nonfuel_xs_queue);
 
   if (need_depletion_rx) {
     #pragma omp target teams distribute parallel for
@@ -285,9 +286,9 @@ void process_advance_particle_events(int n_particles)
     Particle& p = simulation::device_particles[buffer_idx];
     p.event_advance();
     if (p.collision_distance_ > p.boundary_.distance) {
-      simulation::surface_crossing_queue.thread_safe_append({p.E_, buffer_idx});
+      simulation::surface_crossing_queue.thread_safe_append({p.E_, p.material_, buffer_idx});
     } else {
-      simulation::collision_queue.thread_safe_append({p.E_, buffer_idx});
+      simulation::collision_queue.thread_safe_append({p.E_, p.material_, buffer_idx});
     }
   }
   simulation::surface_crossing_queue.sync_size_device_to_host();
@@ -325,7 +326,7 @@ void process_surface_crossing_events()
     if (p.alive())
       dispatch_xs_event(buffer_idx);
     else
-      simulation::revival_queue.thread_safe_append({p.E_, buffer_idx});
+      simulation::revival_queue.thread_safe_append({p.E_, p.material_, buffer_idx});
   }
 
   simulation::calculate_fuel_xs_queue.sync_size_device_to_host();
@@ -351,7 +352,7 @@ void process_collision_events()
     if (p.alive())
       dispatch_xs_event(buffer_idx);
     else
-      simulation::revival_queue.thread_safe_append({p.E_, buffer_idx});
+      simulation::revival_queue.thread_safe_append({p.E_, p.material_, buffer_idx});
   }
 
   simulation::calculate_fuel_xs_queue.sync_size_device_to_host();

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -27,6 +27,20 @@ SharedArray<EventQueueItem> surface_crossing_queue;
 SharedArray<EventQueueItem> collision_queue;
 SharedArray<EventQueueItem> revival_queue;
 
+int e_fuel {0};
+int e_nonfuel {0};
+int e_advance {0};
+int e_surface {0};
+int e_collision {0};
+int e_revival {0};
+
+int64_t ep_fuel {0};
+int64_t ep_nonfuel {0};
+int64_t ep_advance {0};
+int64_t ep_surface {0};
+int64_t ep_collision {0};
+int64_t ep_revival {0};
+
 int current_source_offset;
 
 int sort_counter{0};
@@ -176,6 +190,8 @@ bool depletion_rx_check()
 
 void process_calculate_xs_events_nonfuel()
 {
+  simulation::e_nonfuel++;
+  simulation::ep_nonfuel += simulation::calculate_nonfuel_xs_queue.size();
   simulation::time_event_calculate_xs.start();
   simulation::time_event_calculate_xs_nonfuel.start();
 
@@ -213,6 +229,8 @@ void process_calculate_xs_events_nonfuel()
 
 void process_calculate_xs_events_fuel()
 {
+  simulation::e_fuel++;
+  simulation::ep_fuel += simulation::calculate_fuel_xs_queue.size();
   // Sort fuel lookup queue by energy
   sort_queue(simulation::calculate_fuel_xs_queue);
 
@@ -257,6 +275,8 @@ void process_calculate_xs_events_fuel()
 
 void process_advance_particle_events(int n_particles)
 {
+  simulation::e_advance++;
+  simulation::ep_advance += simulation::advance_particle_queue.size();
   simulation::time_event_advance_particle.start();
 
   #pragma omp target teams distribute parallel for
@@ -293,6 +313,8 @@ void process_advance_particle_events(int n_particles)
 
 void process_surface_crossing_events()
 {
+  simulation::e_surface++;
+  simulation::ep_surface += simulation::surface_crossing_queue.size();
   simulation::time_event_surface_crossing.start();
 
   #pragma omp target teams distribute parallel for
@@ -317,6 +339,8 @@ void process_surface_crossing_events()
 
 void process_collision_events()
 {
+  simulation::e_collision++;
+  simulation::ep_collision += simulation::collision_queue.size();
   simulation::time_event_collision.start();
 
   #pragma omp target teams distribute parallel for
@@ -372,6 +396,8 @@ void process_death_events(int n_particles)
 
 void process_revival_events()
 {
+  simulation::e_revival++;
+  simulation::ep_revival += simulation::revival_queue.size();
   simulation::time_event_revival.start();
 
   // Accumulator for particle weights from any sourced particles

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -42,6 +42,20 @@ std::unordered_map<int32_t, int32_t> material_map;
 Material* materials;
 uint64_t materials_size;
 
+int     serial_materials_size;
+int     serial_materials_offset;
+int     serial_materials_element_size;
+int     serial_materials_element_offset;
+int     serial_materials_thermal_tables_size;
+int     serial_materials_thermal_tables_offset;
+
+int* serial_materials_nuclide;
+int* serial_materials_element;
+int* serial_materials_p0;
+int* serial_materials_mat_nuclide_index;
+ThermalTable* serial_materials_thermal_tables;
+double* serial_materials_atom_density;
+
 } // namespace model
 
 //==============================================================================
@@ -781,7 +795,7 @@ void Material::calculate_neutron_xs_no_depletion(Particle& p) const
   for (int i = 0; i < nuclide_.size(); ++i) {
 
     // Determine microscopic cross sections for this nuclide
-    int i_nuclide = nuclide_[i];
+    int i_nuclide = nuclide(i);
 
     // Perform microscopic XS lookup
     MicroXS nuclide_micro = data::nuclides[i_nuclide].calculate_xs_no_depletion(i_grid, p);
@@ -792,7 +806,7 @@ void Material::calculate_neutron_xs_no_depletion(Particle& p) const
     #endif
 
     // Get atom density of nuclide in material
-    double atom_density = device_atom_density_[i];
+    double atom_density = this->atom_density(i);
 
     // Accumulate this nuclide's contribution to the local macro XS variable
     macro.total      += atom_density * nuclide_micro.total;
@@ -822,7 +836,7 @@ void Material::calculate_neutron_xs(Particle& p) const
   for (int i = 0; i < nuclide_.size(); ++i) {
 
     // Determine microscopic cross sections for this nuclide
-    int i_nuclide = nuclide_[i];
+    int i_nuclide = nuclide(i);
 
     // Perform microscopic XS lookup
     NuclideMicroXS nuclide_micro = data::nuclides[i_nuclide].calculate_xs(i_grid, p, true);
@@ -833,7 +847,7 @@ void Material::calculate_neutron_xs(Particle& p) const
     #endif
 
     // Get atom density of nuclide in material
-    double atom_density = device_atom_density_[i];
+    double atom_density = this->atom_density(i);
 
     // Accumulate this nuclide's contribution to the local macro XS variable
     macro.total      += atom_density * nuclide_micro.total;
@@ -1123,13 +1137,13 @@ void Material::add_nuclide(const std::string& name, double density)
 
 void Material::copy_to_device()
 {
-  nuclide_.copy_to_device();
-  element_.copy_to_device();
-  mat_nuclide_index_.copy_to_device();
-  p0_.copy_to_device();
-  device_atom_density_ = atom_density_.data();
-  #pragma omp target enter data map(to: device_atom_density_[:atom_density_.size()])
-  thermal_tables_.copy_to_device();
+ // nuclide_.copy_to_device();
+  //element_.copy_to_device();
+  //mat_nuclide_index_.copy_to_device();
+  //p0_.copy_to_device();
+  //device_atom_density_ = atom_density_.data();
+  //#pragma omp target enter data map(to: device_atom_density_[:atom_density_.size()])
+  //thermal_tables_.copy_to_device();
   ttb_.copy_to_device();
 }
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -41,20 +41,12 @@ namespace model {
 std::unordered_map<int32_t, int32_t> material_map;
 Material* materials;
 uint64_t materials_size;
-
-int     serial_materials_size;
-int     serial_materials_offset;
-int     serial_materials_element_size;
-int     serial_materials_element_offset;
-int     serial_materials_thermal_tables_size;
-int     serial_materials_thermal_tables_offset;
-
-int* serial_materials_nuclide;
-int* serial_materials_element;
-int* serial_materials_p0;
-int* serial_materials_mat_nuclide_index;
-ThermalTable* serial_materials_thermal_tables;
-double* serial_materials_atom_density;
+vector2d<int> materials_nuclide;
+vector2d<int> materials_element;
+vector2d<double> materials_atom_density;
+vector2d<int> materials_p0;
+vector2d<int> materials_mat_nuclide_index;
+vector2d<ThermalTable> materials_thermal_tables;
 
 } // namespace model
 
@@ -1149,12 +1141,12 @@ void Material::copy_to_device()
 
 void Material::release_from_device()
 {
-  nuclide_.release_device();
-  element_.release_device();
-  mat_nuclide_index_.release_device();
-  p0_.release_device();
-  #pragma omp target exit data map(release: device_atom_density_[:atom_density_.size()])
-  thermal_tables_.release_device();
+  //nuclide_.release_device();
+  //element_.release_device();
+  //mat_nuclide_index_.release_device();
+  //p0_.release_device();
+  //#pragma omp target exit data map(release: device_atom_density_[:atom_density_.size()])
+  //thermal_tables_.release_device();
   ttb_.release_from_device();
 }
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -874,7 +874,7 @@ void Material::calculate_photon_xs(Particle& p) const
     // CALCULATE MICROSCOPIC CROSS SECTION
 
     // Determine microscopic cross sections for this nuclide
-    int i_element = element_[i];
+    int i_element = element(i);
 
     // Calculate microscopic cross section for this nuclide
     const auto& micro {p.photon_xs_[i_element]};
@@ -886,7 +886,7 @@ void Material::calculate_photon_xs(Particle& p) const
     // ADD TO MACROSCOPIC CROSS SECTION
 
     // Copy atom density of nuclide in material
-    double atom_density = device_atom_density_[i];
+    double atom_density = this->atom_density(i);
 
     // Add contributions to material macroscopic cross sections
     p.macro_xs_.total += atom_density * micro.total;
@@ -1129,24 +1129,11 @@ void Material::add_nuclide(const std::string& name, double density)
 
 void Material::copy_to_device()
 {
- // nuclide_.copy_to_device();
-  //element_.copy_to_device();
-  //mat_nuclide_index_.copy_to_device();
-  //p0_.copy_to_device();
-  //device_atom_density_ = atom_density_.data();
-  //#pragma omp target enter data map(to: device_atom_density_[:atom_density_.size()])
-  //thermal_tables_.copy_to_device();
   ttb_.copy_to_device();
 }
 
 void Material::release_from_device()
 {
-  //nuclide_.release_device();
-  //element_.release_device();
-  //mat_nuclide_index_.release_device();
-  //p0_.release_device();
-  //#pragma omp target exit data map(release: device_atom_density_[:atom_density_.size()])
-  //thermal_tables_.release_device();
   ttb_.release_from_device();
 }
 

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -641,7 +641,7 @@ MicroXS Nuclide::calculate_xs_no_depletion(int i_log_union, Particle& p)
 
   const auto& mat = model::materials[p.material_];
   for (int s = 0; s < mat.thermal_tables_.size(); s++) {
-    const auto& sab {mat.thermal_tables_[s]};
+    const auto& sab {mat.thermal_tables(s)};
     if (index_ == sab.index_nuclide) {
       // Get index in sab_tables
       i_sab = sab.index_table;
@@ -1044,7 +1044,7 @@ NuclideMicroXS Nuclide::calculate_xs(int i_log_union, Particle& p, bool need_dep
 
   const auto& mat = model::materials[p.material_];
   for (int s = 0; s < mat.thermal_tables_.size(); s++) {
-    const auto& sab {mat.thermal_tables_[s]};
+    const auto& sab {mat.thermal_tables(s)};
     if (index_ == sab.index_nuclide) {
       // Get index in sab_tables
       i_sab = sab.index_table;

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -627,6 +627,409 @@ double Nuclide::elastic_xs_0K(double E) const
   return (1.0 - f)*elastic_0K_[i_grid] + f*elastic_0K_[i_grid + 1];
 }
 
+MicroXS Nuclide::calculate_xs_no_depletion(int i_log_union, Particle& p)
+{
+  double E = p.E_;
+  double sqrtkT = p.sqrtkT_;
+  
+  // ======================================================================
+  // CHECK FOR SAB TABLE BEGIN
+  // ======================================================================
+
+  int i_sab = C_NONE;
+  double sab_frac = 0.0;
+
+  const auto& mat = model::materials[p.material_];
+  for (int s = 0; s < mat.thermal_tables_.size(); s++) {
+    const auto& sab {mat.thermal_tables_[s]};
+    if (index_ == sab.index_nuclide) {
+      // Get index in sab_tables
+      i_sab = sab.index_table;
+      sab_frac = sab.fraction;
+
+      // If particle energy is greater than the highest energy for the
+      // S(a,b) table, then don't use the S(a,b) table
+      if (p.E_ > data::device_thermal_scatt[i_sab].energy_max_) i_sab = C_NONE;
+    }
+  }
+  
+  // ======================================================================
+  // CHECK FOR SAB TABLE END
+  // ======================================================================
+
+  #ifndef NO_MICRO_XS_CACHE
+  {
+    auto& micro {p.neutron_xs_[index_]};
+    // Check if a microscopic XS lookup is even required. If all state variables are the same, then we can
+    // just accumulate the micro XS data directly into the macro and skip the rest of this function.
+    if (     E      == micro.last_E
+          && sqrtkT == micro.last_sqrtkT
+          && i_sab     == micro.index_sab
+          && sab_frac  == micro.sab_frac
+       )
+    {
+      return micro;
+    }
+  }
+  #endif
+
+  double total;
+  double elastic = CACHE_INVALID;
+  double absorption;
+  double fission;
+  double nu_fission;
+  double photon_prod = 0.0;
+
+  bool use_mp = false;
+  // Check to see if there is multipole data present at this energy
+  if (multipole()) {
+    use_mp = (E >= multipole()->E_min_ && E <= multipole()->E_max_);
+  }
+
+  int i_temp = -1;
+  int i_grid;
+  double f;
+  // Evaluate multipole or interpolate
+  if (use_mp) {
+    // ======================================================================
+    // MULTIPOLE LOOKUP BEGIN
+    // ======================================================================
+
+    // Call multipole kernel
+    double sig_s, sig_a, sig_f;
+    std::tie(sig_s, sig_a, sig_f) = multipole()->evaluate(E, sqrtkT);
+
+    total = sig_s + sig_a;
+    elastic = sig_s;
+    absorption = sig_a;
+    fission = sig_f;
+    nu_fission = fissionable_ ?
+      sig_f * this->nu(E, EmissionMode::total) : 0.0;
+
+    // Ensure these values are set
+    // Note, the only time either is used is in one of 4 places:
+    // 1. physics.cpp - scatter - For inelastic scatter.
+    // 2. physics.cpp - sample_fission - For partial fissions.
+    // 3. tally.F90 - score_general - For tallying on MTxxx reactions.
+    // 4. nuclide.cpp - calculate_urr_xs - For unresolved purposes.
+    // It is worth noting that none of these occur in the resolved
+    // resonance range, so the value here does not matter.  index_temp is
+    // set to -1 to force a segfault in case a developer messes up and tries
+    // to use it with multipole.
+    i_grid = -1;
+    f = 0.0;
+
+    // ======================================================================
+    // MULTIPOLE LOOKUP END
+    // ======================================================================
+  } else {
+    // ======================================================================
+    // POINTWISE LOOKUP BEGIN
+    // ======================================================================
+
+    // Find the appropriate temperature index.
+    double kT = sqrtkT*sqrtkT;
+    switch (settings::temperature_method) {
+    case TemperatureMethod::NEAREST:
+      {
+        double max_diff = INFTY;
+        for (int t = 0; t < kTs_.size(); ++t) {
+          double diff = std::abs(kTs_[t] - kT);
+          if (diff < max_diff) {
+            i_temp = t;
+            max_diff = diff;
+          }
+        }
+      }
+      break;
+
+    case TemperatureMethod::INTERPOLATION:
+      // Find temperatures that bound the actual temperature
+      for (i_temp = 0; i_temp < kTs_.size() - 1; ++i_temp) {
+        if (kTs_[i_temp] <= kT && kT < kTs_[i_temp + 1]) break;
+      }
+
+      // Randomly sample between temperature i and i+1
+      f = (kT - kTs_[i_temp]) / (kTs_[i_temp + 1] - kTs_[i_temp]);
+      if (f > prn(p.current_seed())) ++i_temp;
+      break;
+    }
+
+    // Offset index grid
+    int index_offset = i_temp * (settings::n_log_bins + 1);
+    int* grid_index = &flat_grid_index_[index_offset];
+
+    // Offset energy grid
+    int energy_offset = flat_temp_offsets_[i_temp];
+    double* energy = &flat_grid_energy_[energy_offset];
+
+    // Offset xs
+    int xs_offset = flat_temp_offsets_[i_temp] * 5;
+    double* xs = &flat_xs_[xs_offset];
+
+    // Determine # of gridpoints for this temperature
+    int num_gridpoints;
+    if (i_temp < kTs_.size() - 1) {
+      num_gridpoints = flat_temp_offsets_[i_temp + 1] - energy_offset;
+    } else {
+      num_gridpoints = total_energy_gridpoints_ - energy_offset;
+    }
+
+    // Determine the energy grid index using a logarithmic mapping to
+    // reduce the energy range over which a binary search needs to be
+    // performed
+
+    if (E < energy[0]) {
+      i_grid = 0;
+    } else if (E > energy[num_gridpoints-1]) {
+      i_grid = num_gridpoints - 2;
+    } else {
+      // Determine bounding indices based on which equal log-spaced
+      // interval the energy is in
+      int i_low  = grid_index[i_log_union];
+      int i_high = grid_index[i_log_union + 1] + 1;
+
+      // Perform binary search over reduced range
+      // Note the STL-based binary search seems to work on llvm/V100 but not elsewhere
+      //i_grid = i_low + lower_bound_index(&energy[i_low], &energy[i_high], E);
+
+      // Iterative linear search (a few percent faster on device due to reduced branching)
+      for (; i_low < i_high - 1; i_low++) {
+        if (E < energy[i_low + 1])
+          break;
+      }
+      i_grid = i_low;
+    }
+
+    // check for rare case where two energy points are the same
+    if (energy[i_grid] == energy[i_grid + 1]) ++i_grid;
+
+    // 1D indexing conversion for lower XS value
+    int i_grid1D = i_grid * 5;
+    int i_next1D = (i_grid + 1) * 5;
+
+    // Execute All Lookups (in CUDA, it would be nice to try __ldg())
+    double total_low            = xs[i_grid1D + XS_TOTAL];
+    double absorption_low       = xs[i_grid1D + XS_ABSORPTION];
+    double fission_low          = xs[i_grid1D + XS_FISSION];
+    double nu_fission_low       = xs[i_grid1D + XS_NU_FISSION];
+    double photon_prod_low      = xs[i_grid1D + XS_PHOTON_PROD];
+
+    double total_next       = xs[i_next1D + XS_TOTAL];
+    double absorption_next  = xs[i_next1D + XS_ABSORPTION];
+    double fission_next     = xs[i_next1D + XS_FISSION];
+    double nu_fission_next  = xs[i_next1D + XS_NU_FISSION];
+    double photon_prod_next = xs[i_next1D + XS_PHOTON_PROD];
+
+    // Calculate interpolation factor and complement
+    f = (E - energy[i_grid]) /
+      (energy[i_grid + 1]- energy[i_grid]);
+    double f_comp = 1.0 - f;
+
+    // Perform Interpolation
+    total       = f_comp * total_low       + f * total_next;
+    absorption  = f_comp * absorption_low  + f * absorption_next;
+    fission     = f_comp * fission_low     + f * fission_next;
+    nu_fission  = f_comp * nu_fission_low  + f * nu_fission_next;
+    photon_prod = f_comp * photon_prod_low + f * photon_prod_next;
+
+    // ======================================================================
+    // POINTWISE LOOKUP END
+    // ======================================================================
+  }
+
+  int index_sab = C_NONE;
+  double thermal = 0.0;
+  double thermal_elastic = 0.0;
+  int index_temp_sab;
+
+  // ======================================================================
+  // SAB BEGIN
+  // ======================================================================
+
+  // If there is S(a,b) data for this nuclide, we need to set the sab_scatter
+  // and sab_elastic cross sections and correct the total and elastic cross
+  // sections.
+  if (i_sab >= 0)
+  {
+    // Set flag that S(a,b) treatment should be used for scattering
+    index_sab = i_sab;
+
+    // Calculate the S(a,b) cross section
+    int sab_i_temp;
+    double sab_elastic;
+    double sab_inelastic;
+    data::device_thermal_scatt[i_sab].calculate_xs(E, sqrtkT, &sab_i_temp, &sab_elastic, &sab_inelastic, p.current_seed());
+
+    // Store the S(a,b) cross sections.
+    thermal = sab_frac * (sab_elastic + sab_inelastic);
+    thermal_elastic = sab_frac * sab_elastic;
+
+    // Calculate free atom elastic cross section
+    if (elastic == CACHE_INVALID) {
+      elastic = this->calculate_elastic_xs(i_temp, i_grid, f);
+    }
+
+    // Correct total and elastic cross sections
+    total = total + thermal - sab_frac * elastic;
+    elastic = thermal + (1.0 - sab_frac) * elastic;
+
+    // Save temperature index and thermal fraction
+    index_temp_sab = sab_i_temp;
+  } else {
+    sab_frac = 0.0;
+  }
+  // ======================================================================
+  // SAB END
+  // ======================================================================
+
+  bool use_ptable = false;
+
+  // ======================================================================
+  // URR BEGIN
+  // ======================================================================
+
+  // If the particle is in the unresolved resonance range and there are
+  // probability tables, we need to determine cross sections from the table
+  if (settings::urr_ptables_on && urr_present_ && !use_mp) {
+    int n = urr_data_[i_temp].n_energy_;
+    if ((E > urr_data_[i_temp].device_energy_[0]) &&
+        (E < urr_data_[i_temp].device_energy_[n-1]))
+    {
+      use_ptable = true;
+
+      // Create a shorthand for the URR data
+      const auto& urr = urr_data_[i_temp];
+
+      // Determine the energy table
+      int i_energy = 0;
+      while (E >= urr.device_energy_[i_energy + 1]) {++i_energy;};
+
+      // Sample the probability table using the cumulative distribution
+
+      // Random nmbers for the xs calculation are sampled from a separate stream.
+      // This guarantees the randomness and, at the same time, makes sure we
+      // reuse random numbers for the same nuclide at different temperatures,
+      // therefore preserving correlation of temperature in probability tables.
+      p.stream_ = STREAM_URR_PTABLE;
+      //TODO: to maintain the same random number stream as the Fortran code this
+      //replaces, the seed is set with index_ + 1 instead of index_
+      double r = future_prn(static_cast<int64_t>(index_ + 1), *p.current_seed());
+      p.stream_ = STREAM_TRACKING;
+
+      int i_low = 0;
+      while (urr.prob(i_energy, URRTableParam::CUM_PROB, i_low) <= r) {++i_low;};
+
+      int i_up = 0;
+      while (urr.prob(i_energy + 1, URRTableParam::CUM_PROB, i_up) <= r) {++i_up;};
+
+      // Determine elastic, fission, and capture cross sections from the
+      // probability table
+      double p_elastic = 0.;
+      double p_fission = 0.;
+      double p_capture = 0.;
+      double p_f;
+      if (urr.interp_ == Interpolation::lin_lin) {
+        // Determine the interpolation factor on the table
+        p_f = (E - urr.device_energy_[i_energy]) /
+          (urr.device_energy_[i_energy + 1] - urr.device_energy_[i_energy]);
+
+        p_elastic = (1. - p_f) * urr.prob(i_energy, URRTableParam::ELASTIC, i_low) +
+          p_f * urr.prob(i_energy + 1, URRTableParam::ELASTIC, i_up);
+        p_fission = (1. - p_f) * urr.prob(i_energy, URRTableParam::FISSION, i_low) +
+          p_f * urr.prob(i_energy + 1, URRTableParam::FISSION, i_up);
+        p_capture = (1. - p_f) * urr.prob(i_energy, URRTableParam::N_GAMMA, i_low) +
+          p_f * urr.prob(i_energy + 1, URRTableParam::N_GAMMA, i_up);
+      } else if (urr.interp_ == Interpolation::log_log) {
+        // Determine interpolation factor on the table
+        p_f = std::log(E / urr.device_energy_[i_energy]) /
+          std::log(urr.device_energy_[i_energy + 1] / urr.device_energy_[i_energy]);
+
+        // Calculate the elastic cross section/factor
+        if ((urr.prob(i_energy, URRTableParam::ELASTIC, i_low) > 0.) &&
+            (urr.prob(i_energy + 1, URRTableParam::ELASTIC, i_up) > 0.)) {
+          p_elastic =
+            std::exp((1. - p_f) *
+                std::log(urr.prob(i_energy, URRTableParam::ELASTIC, i_low)) +
+                p_f * std::log(urr.prob(i_energy + 1, URRTableParam::ELASTIC, i_up)));
+        } else {
+          p_elastic = 0.;
+        }
+
+        // Calculate the fission cross section/factor
+        if ((urr.prob(i_energy, URRTableParam::FISSION, i_low) > 0.) &&
+            (urr.prob(i_energy + 1, URRTableParam::FISSION, i_up) > 0.)) {
+          p_fission =
+            std::exp((1. - p_f) *
+                std::log(urr.prob(i_energy, URRTableParam::FISSION, i_low)) +
+                p_f * std::log(urr.prob(i_energy + 1, URRTableParam::FISSION, i_up)));
+        } else {
+          p_fission = 0.;
+        }
+
+        // Calculate the capture cross section/factor
+        if ((urr.prob(i_energy, URRTableParam::N_GAMMA, i_low) > 0.) &&
+            (urr.prob(i_energy + 1, URRTableParam::N_GAMMA, i_up) > 0.)) {
+          p_capture =
+            std::exp((1. - p_f) *
+                std::log(urr.prob(i_energy, URRTableParam::N_GAMMA, i_low)) +
+                p_f * std::log(urr.prob(i_energy + 1, URRTableParam::N_GAMMA, i_up)));
+        } else {
+          p_capture = 0.;
+        }
+      }
+
+      // Determine the treatment of inelastic scattering
+      double p_inelastic = 0.;
+      if (urr.inelastic_flag_ != C_NONE) {
+        // Determine inelastic scattering cross section
+        auto rx = reactions_[urr_inelastic_].obj();
+        p_inelastic = rx.xs(i_temp, i_grid,f);
+      }
+
+      // Multiply by smooth cross-section if needed
+      if (urr.multiply_smooth_) {
+        p_elastic *= this->calculate_elastic_xs(i_temp, i_grid, f);
+        p_capture *= (absorption - fission);
+        p_fission *= fission;
+      }
+
+      // Check for negative values
+      if (p_elastic < 0.) {p_elastic = 0.;}
+      if (p_fission < 0.) {p_fission = 0.;}
+      if (p_capture < 0.) {p_capture = 0.;}
+
+      // Set elastic, absorption, fission, total, and capture x/s. Note that the
+      // total x/s is calculated as a sum of partials instead of the table-provided
+      // value
+      elastic = p_elastic;
+      absorption = p_capture + p_fission;
+      fission = p_fission;
+      total = p_elastic + p_inelastic + p_capture + p_fission;
+
+      // Determine nu-fission cross-section
+      if (fissionable_) {
+        nu_fission = nu(E, EmissionMode::total) * fission;
+      }
+    }
+  }
+  // ======================================================================
+  // URR END
+  // ======================================================================
+
+  // ======================================================================
+  // Return MicroXS
+  // ======================================================================
+  
+  MicroXS micro;
+  micro.total         = total;
+  micro.absorption    = absorption;
+  micro.fission       = fission;
+  micro.nu_fission    = nu_fission;
+
+  return micro;
+}
+
 NuclideMicroXS Nuclide::calculate_xs(int i_log_union, Particle& p, bool need_depletion_rx)
 {
   double E = p.E_;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -375,7 +375,6 @@ void print_generation()
     fmt::print("   {:8.5f} +/-{:8.5f}", simulation::keff, simulation::keff_std);
   }
 
-  fmt::print("   {:d}  {:d}", simulation::n_events, simulation::n_work);
   std::cout << std::endl;
 }
 
@@ -425,18 +424,23 @@ void print_runtime()
   // display header block
   header("Runtime Information", 6);
   if (settings::verbosity < 6) return;
-  std::cout << "Fuel XS events:    " << simulation::e_fuel      << " " << simulation::ep_fuel << std::endl;
-  std::cout << "Nonfuel XS events: " << simulation::e_nonfuel   << " " << simulation::ep_nonfuel << std::endl; 
-  std::cout << "Advance events:    " << simulation::e_advance   << " " << simulation::ep_advance << std::endl; 
-  std::cout << "Surface events:    " << simulation::e_surface   << " " << simulation::ep_surface << std::endl; 
-  std::cout << "Collision events:  " << simulation::e_collision << " " << simulation::ep_collision << std::endl; 
-  std::cout << "Revival events:    " << simulation::e_revival   << " " << simulation::ep_revival << std::endl; 
+
 
   fmt::print(" Simulation Algorithm              = ");
-  if (settings::event_based )
+  if (settings::event_based) {
     fmt::print("Event-Based\n");
-  else
+    int64_t events = simulation::e_fuel + simulation::e_nonfuel + simulation::e_advance + simulation::e_surface + simulation::e_collision + simulation::e_revival;
+    int64_t particle_events = simulation::ep_fuel + simulation::ep_nonfuel + simulation::ep_advance + simulation::ep_surface + simulation::ep_collision + simulation::ep_revival;
+    std::cout << " Total Kernel Calls, Par-Events    = " << std::setw(5) << std::left << events << ", " << particle_events << " (on MPI rank 0)" << std::endl;
+    std::cout << "   Fuel XS                         = " << std::setw(5) << std::left << simulation::e_fuel << ", " << simulation::ep_fuel << std::endl;
+    std::cout << "   Nonfuel XS                      = " << std::setw(5) << std::left << simulation::e_nonfuel << ", " << simulation::ep_nonfuel << std::endl;
+    std::cout << "   Advance                         = " << std::setw(5) << std::left << simulation::e_advance << ", " << simulation::ep_advance << std::endl;
+    std::cout << "   Surface                         = " << std::setw(5) << std::left << simulation::e_surface << ", " << simulation::ep_surface << std::endl;
+    std::cout << "   Collision                       = " << std::setw(5) << std::left << simulation::e_collision << ", " << simulation::ep_collision << std::endl;
+    std::cout << "   Revival                         = " << std::setw(5) << std::left << simulation::e_revival << ", " << simulation::ep_revival << std::endl;
+  } else {
     fmt::print("History-Based\n");
+  }
 
   fmt::print(" Simulation Execution Location     = ");
   if (was_device_used())

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -425,6 +425,12 @@ void print_runtime()
   // display header block
   header("Runtime Information", 6);
   if (settings::verbosity < 6) return;
+  std::cout << "Fuel XS events:    " << simulation::e_fuel      << " " << simulation::ep_fuel << std::endl;
+  std::cout << "Nonfuel XS events: " << simulation::e_nonfuel   << " " << simulation::ep_nonfuel << std::endl; 
+  std::cout << "Advance events:    " << simulation::e_advance   << " " << simulation::ep_advance << std::endl; 
+  std::cout << "Surface events:    " << simulation::e_surface   << " " << simulation::ep_surface << std::endl; 
+  std::cout << "Collision events:  " << simulation::e_collision << " " << simulation::ep_collision << std::endl; 
+  std::cout << "Revival events:    " << simulation::e_revival   << " " << simulation::ep_revival << std::endl; 
 
   fmt::print(" Simulation Algorithm              = ");
   if (settings::event_based )

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -466,7 +466,7 @@ void print_runtime()
     show_time("XS lookups (Total)", time_event_calculate_xs.elapsed(), 2);
     show_time("XS lookups (Fuel)", time_event_calculate_xs_fuel.elapsed(), 2);
     show_time("XS lookups (Non-Fuel)", time_event_calculate_xs_nonfuel.elapsed(), 2);
-    show_time("Fuel energy sorting", time_event_sort.elapsed(), 2);
+    show_time("Material/Energy sorting", time_event_sort.elapsed(), 2);
     show_time("Avg. time per sort", time_event_sort.elapsed() / sort_counter, 2);
     show_time("Advancing", time_event_advance_particle.elapsed(), 2);
     show_time("Tallying", time_event_tally.elapsed(), 2);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -374,6 +374,8 @@ void print_generation()
   if (n > 1) {
     fmt::print("   {:8.5f} +/-{:8.5f}", simulation::keff, simulation::keff_std);
   }
+
+  fmt::print("   {:d}  {:d}", simulation::n_events, simulation::n_work);
   std::cout << std::endl;
 }
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -213,9 +213,15 @@ Particle::event_calculate_xs_dispatch()
 }
 
 void
-Particle::event_calculate_xs_execute(bool need_depletion_rx)
+Particle::event_calculate_xs_execute()
 {
-  model::materials[material_].calculate_xs(*this, need_depletion_rx);
+  model::materials[material_].calculate_xs(*this);
+}
+
+void
+Particle::event_calculate_xs_execute_no_depletion()
+{
+  model::materials[material_].calculate_xs_no_depletion(*this);
 }
 
 void
@@ -223,7 +229,7 @@ Particle::event_calculate_xs(bool need_depletion_rx)
 {
   bool needs_lookup = this->event_calculate_xs_dispatch();
   if (needs_lookup)
-    this->event_calculate_xs_execute(need_depletion_rx);
+    this->event_calculate_xs_execute();
 }
 
 void

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -484,13 +484,13 @@ int sample_nuclide(Particle& p)
 
   double prob = 0.0;
   for (int i = 0; i < n; ++i) {
-    int i_nuclide = mat.nuclide_[i];
+    int i_nuclide = mat.nuclide(i);
 
     // Lookup micro XS (no depletion XS data is needed for collisions)
     NuclideMicroXS xs = data::nuclides[i_nuclide].calculate_xs(i_grid, p, false);
     
     // Get atom density
-    double atom_density = mat.device_atom_density_[i];
+    double atom_density = mat.atom_density(i);
 
     // Increment probability to compare to cutoff
     prob += atom_density * xs.total;
@@ -522,8 +522,8 @@ int sample_nuclide(Particle& p)
   double prob = 0.0;
   for (int i = 0; i < n; ++i) {
     // Get atom density
-    int i_nuclide = mat.nuclide_[i];
-    double atom_density = mat.device_atom_density_[i];
+    int i_nuclide = mat.nuclide(i);
+    double atom_density = mat.device_atom_density(i);
 
     // Increment probability to compare to cutoff
     prob += atom_density * p.neutron_xs_[i_nuclide].total;
@@ -771,8 +771,8 @@ void scatter(Particle& p, int i_nuclide)
   // Sample new outgoing angle for isotropic-in-lab scattering
   const auto& mat {model::materials[p.material_]};
   if (!mat.p0_.empty()) {
-    int i_nuc_mat = mat.mat_nuclide_index_[i_nuclide];
-    if (mat.p0_[i_nuc_mat]) {
+    int i_nuc_mat = mat.mat_nuclide_index(i_nuclide);
+    if (mat.p0(i_nuc_mat)) {
       // Sample isotropic-in-lab outgoing direction
       double mu = 2.0*prn(p.current_seed()) - 1.0;
       double phi = 2.0*PI*prn(p.current_seed());

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -550,8 +550,8 @@ int sample_element(Particle& p)
   double prob = 0.0;
   for (int i = 0; i < mat.element_.size(); ++i) {
     // Find atom density
-    int i_element = mat.element_[i];
-    double atom_density = mat.device_atom_density_[i];
+    int i_element = mat.element(i);
+    double atom_density = mat.atom_density(i);
 
     // Determine microscopic cross section
     double sigma = atom_density * p.photon_xs_[i_element].total;
@@ -560,7 +560,7 @@ int sample_element(Particle& p)
     prob += sigma;
     if (prob > cutoff) {
       // Save which nuclide particle had collision with for tally purpose
-      p.event_nuclide_ = mat.nuclide_[i];
+      p.event_nuclide_ = mat.nuclide(i);
 
       return i_element;
     }

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -487,8 +487,7 @@ int sample_nuclide(Particle& p)
     int i_nuclide = mat.nuclide_[i];
 
     // Lookup micro XS (no depletion XS data is needed for collisions)
-    bool need_depletion_rx = false;
-    NuclideMicroXS xs = data::nuclides[i_nuclide].calculate_xs(i_grid, p, need_depletion_rx);
+    NuclideMicroXS xs = data::nuclides[i_nuclide].calculate_xs(i_grid, p, false);
     
     // Get atom density
     double atom_density = mat.device_atom_density_[i];

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -145,6 +145,17 @@ int openmc_simulation_init()
     }
   }
 
+  // Count distribcell
+  uint64_t n_distribcells = 0;
+  for( int i = 0; i < model::cells.size(); i++ )
+  {
+    Cell& cell = model::cells[i];
+    if(cell.type_ != Fill::MATERIAL)
+      continue;
+    n_distribcells += cell.n_instances_;
+  }
+  std::cout << "Number of distribcells = " << n_distribcells << std::endl;
+
   #ifdef OPENMC_MPI
   MPI_Barrier( mpi::intracomm );
   #endif

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -607,7 +607,6 @@ void Tally::init_results()
 {
   n_scores_ = scores_.size() * nuclides_.size();
   results_size_ = n_filter_bins_ * n_scores_ * 3;
-  std::cout << "Allocating tally " << id_ << " buffer for " << n_filter_bins_ << " bins with " << n_scores_ << " scores each. Total size: " << (double) results_size_ * sizeof(double) / 1.0e6 << " MB" << std::endl;
   results_ = static_cast<double*>(malloc(results_size_ * sizeof(double)));
 }
 

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -2407,9 +2407,9 @@ score_tracklength_tally(Particle& p, double distance, bool need_depletion_rx)
         NuclideMicroXS micro;
         if (i_nuclide >= 0) {
           if (p.material_ != MATERIAL_VOID) {
-            auto j = model::materials[p.material_].mat_nuclide_index_[i_nuclide];
+            auto j = model::materials[p.material_].mat_nuclide_index(i_nuclide);
             if (j == C_NONE) continue;
-            atom_density = model::materials[p.material_].device_atom_density_[j];
+            atom_density = model::materials[p.material_].atom_density(j);
             #ifdef NO_MICRO_XS_CACHE
             micro = data::nuclides[i_nuclide].calculate_xs(i_grid, p, need_depletion_rx);
             #else


### PR DESCRIPTION
## Introduction 

This PR introduces a variety of optimizations and cleanups that resulted from performance analysis of the SMR challenge problem. These optimizations are useful for a wide variety of problems, but have particular impact for the SMR due to that problem having lots of material regions and a fairly large tally space.

## Specialization of neutron XS lookup functions

This optimizations splits the neutron XS functions into multiple versions with/without depletion XS lookups. This does have a noticeable impact on performance (about 10% on the A100). While previously we had simply not been performing the depletion lookups if not needed in the XS kernel, we still had to have a number of variables passed around between functions which causes additional memory usage/movement, as well as additional register usage in the kernel. I did some experimentation with this and did find that it was optimal to actually break the functions up into separate versions so that the types of data passed back could be reduced for inactive batches or active batches that don't require depletion cross section data. Currently, this means that a lot of code is duplicated! Ideally we could find a way to do the different types of lookups efficiently without this high-level specialization, but for now it seems this is an easy enough fix.

One nice side-effect of this optimization is we can view the kernel timings from utilities like `iprof` and `nvprof` in inactive vs. active iterations of the code as they are launched at a high level as two different kernels.

## Changes to XS lookup queue sorting policy

We now sort non-fuel XS lookups in addition to fuel XS lookups. Notably, fuel materials are not sorted by material type (as depleted problems may have O(100k+) material types). However, non-fuel materials are sorted by material type primary, with the energy sort being secondary. This has a nice speedup in the range of 5-10% for A100 where the on-device CUDA sorting is very fast, so the additional overhead of the sort is outweighed by the speedup of non-fuel material lookups. This speedup is most apparent in the SMR which has many more non-fuel XS lookup events as compared to the HM large model we had traditionally been using.

## Serialization of material data

As our working SMR model has about 200k material types, and each material type originally involved mapping of up to 7 pointers, the model in aggregate was mapping over 1.4 million pointers to device with OpenMP. This took several minutes of mapping on all devices. While having this many pointers did not have a kernel performance on some GPUs, on others it created odd performance issues with some key OpenMP operations. To both speed up mapping and avoid these performance issues, it seemed like a good idea to rethink how we were mapping our `Material` objects to device.

To this end, I have added a new serialized `openmc::vector2d` class that inherits from our `openmc::vector` class. The new class adds a few utility functions with the purpose of converting many vector objects into a single 2D vector, where each original vector is copied into a different row of the 2D vector.

To represent six of the vector fields in the `Material` class, we now have six different top level global `vector2d` objects:

```C++
vector2d<int> materials_nuclide;
vector2d<int> materials_element;
vector2d<double> materials_atom_density;
vector2d<int> materials_p0;
vector2d<int> materials_mat_nuclide_index;
vector2d<ThermalTable> materials_thermal_tables;
```

Material data gets initialized normally and stored in the vector fields of the `Material` class. However, after program init when mapping data to device, we do some analysis on the materials array and copy relevant data in from the relevant fields in the `Material` object:

```C++
  //----------------------------------------------------------------------------
  // Data
  ...
  vector<int> nuclide_; //!< Indices in nuclides vector
  vector<int> element_; //!< Indices in elements vector
  xt::xtensor<double, 1> atom_density_; //!< Nuclide atom density in [atom/b-cm]
  ...
  vector<int> p0_; //!< Indicate which nuclides are to be treated with iso-in-lab scattering
 ...
  vector<int> mat_nuclide_index_;
  ...
  vector<ThermalTable> thermal_tables_;
  ...
```

and store it in the new `vector2d` objects for serialization.

So, to be clear, the original fields in the `Material` object still exist, we just do not map them to device. Rather, we copy their data into rows of the top level `vector2d` objects, which occurs in `device_alloc.cpp`

Now, when a particle needs to access this data (e.g., in the neutron XS lookup routine), instead of reading from the `Material` vector fields, it instead will read from the global `vector2d` object. To make refactoring as easy as possible, we define accessor functions in the `Material` class to do this for us, such that throughout OpenMC we only need to refactor from:

```C++
int i_nuclide = mat.nuclide_[i];
double atom_density = mat.device_atom_density_[i];
```

we now just do:

```C++
int i_nuclide = mat.nuclide(i); // uses accessors that will read from the global vector2d for this array
double atom_density = mat.atom_density(i);
```

At the end of the day, the use of this method means we only have to map a few pointers rather than millions, and the logic for converting the vector fields to global vector2d could be followed pretty easily for other classes if we really wanted to.

However, I will note that there are a few shortcomings with this method:

- We still retain the original vector fields in the `Material` class (though they don't get mapped to device). Fully eliminating them is of course possible, but that would require perhaps more involved refactoring and pain for the program file i/o and initialization routines.
- The other problem with my method here is that there is nothing stopping people from accessing the vestigial `Material` vectors in device code which would be bad.
- There is a decent number of lines of new code in the `device_alloc.cpp` file to get everything serialized, but it is at least very straightforward code as the logic for doing the key operations is contained in the `vector2d` class.

Anyway, let me know if someone sees a cleaner way of doing this, I'm not at all deadset on the strategy!

## Performance

Performance improvements on an A100 GPU (in terms of kparticles/sec) for this PR:

  | Old | This PR | Speedup
-- | -- | -- | --
HM Large -  1 MPI Rank - Inactive | 364 | 409 | 1.12
HM Large -  4 MPI Rank - Inactive | 397 | 449 | 1.13
SMR - 1 MPI Rank - Active | 165 | 171 | 1.04
SMR - 4 MPI Rank - Active | 161 | 182 | 1.13

Note the SMR performance numbers are for active batches with multipole XS and 200k unique material regions, whereas the HM Large problem is for inactive batches with pointwise XS and a single fuel material.



