### PR TITLE
Material Serialization

### DIFF
--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -25,12 +25,24 @@ namespace openmc {
 
 class Material;
 
+struct ThermalTable {
+   int index_table; //!< Index of table in data::thermal_scatt
+   int index_nuclide; //!< Index in nuclide_
+   double fraction; //!< How often to use table
+ };
+
 namespace model {
 
 extern std::unordered_map<int32_t, int32_t> material_map;
 #pragma omp declare target
 extern Material* materials;
 extern uint64_t materials_size;
+extern vector2d<int> materials_nuclide;
+extern vector2d<int> materials_element;
+extern vector2d<double> materials_atom_density;
+extern vector2d<int> materials_p0;
+extern vector2d<int> materials_mat_nuclide_index;
+extern vector2d<ThermalTable> materials_thermal_tables;
 #pragma omp end declare target
 
 } // namespace model
@@ -42,14 +54,6 @@ extern uint64_t materials_size;
 class Material
 {
 public:
-  //----------------------------------------------------------------------------
-  // Types
-  struct ThermalTable {
-    int index_table; //!< Index of table in data::thermal_scatt
-    int index_nuclide; //!< Index in nuclide_
-    double fraction; //!< How often to use table
-  };
-
   //----------------------------------------------------------------------------
   // Constructors, destructors, factory functions
   Material() {};
@@ -145,6 +149,16 @@ public:
   void copy_to_device();
   void release_from_device();
 
+  // Serialized global array accessor functions
+  #pragma omp declare target
+  int& nuclide(int i) const {                 return model::materials_nuclide(          index_, i);}
+  int& element(int i) const {                 return model::materials_element(          index_, i);}
+  double& atom_density(int i) const {         return model::materials_atom_density(     index_, i);}
+  int& p0(int i) const {                      return model::materials_p0(               index_, i);}
+  int& mat_nuclide_index(int i)const  {       return model::materials_mat_nuclide_index(index_, i);}
+  ThermalTable& thermal_tables(int i) const { return model::materials_thermal_tables(   index_, i);}
+  #pragma omp end declare target
+
   //----------------------------------------------------------------------------
   // Data
   int32_t id_ {C_NONE}; //!< Unique ID
@@ -170,6 +184,7 @@ public:
   vector<ThermalTable> thermal_tables_;
 
   Bremsstrahlung ttb_;
+  gsl::index index_;
 
 private:
   //----------------------------------------------------------------------------
@@ -191,7 +206,6 @@ private:
 
   //----------------------------------------------------------------------------
   // Private data members
-  gsl::index index_;
 
   //! \brief Default temperature for cells containing this material.
   //!

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -183,7 +183,6 @@ public:
   vector<ThermalTable> thermal_tables_;
 
   Bremsstrahlung ttb_;
-  gsl::index index_;
 
 private:
   //----------------------------------------------------------------------------
@@ -205,6 +204,7 @@ private:
 
   //----------------------------------------------------------------------------
   // Private data members
+  gsl::index index_;
 
   //! \brief Default temperature for cells containing this material.
   //!

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -166,7 +166,6 @@ public:
   vector<int> nuclide_; //!< Indices in nuclides vector
   vector<int> element_; //!< Indices in elements vector
   xt::xtensor<double, 1> atom_density_; //!< Nuclide atom density in [atom/b-cm]
-  double* device_atom_density_;
   double density_; //!< Total atom density in [atom/b-cm]
   double density_gpcc_; //!< Total atom density in [g/cm^3]
   double volume_ {-1.0}; //!< Volume in [cm^3]

--- a/include/openmc/vector.h
+++ b/include/openmc/vector.h
@@ -6,6 +6,7 @@
 #include <initializer_list>
 #include <iterator> // for reverse_iterator
 #include <utility> // for swap
+#include "xtensor/xtensor.hpp"
 
 #include <omp.h>
 
@@ -137,6 +138,8 @@ public:
     size_ = count;
   }
 
+  size_type footprint() { return size_ * sizeof(T); }
+
   void reserve(size_type n) {
     if (n <= capacity_) return;
 
@@ -209,7 +212,7 @@ public:
 #pragma GCC diagnostic pop
   }
 
-private:
+protected:
   T* data_;
   size_type size_;
   size_type capacity_;
@@ -388,6 +391,77 @@ void vector<T>::assign(InputIt first, InputIt last)
   }
 }
 
+template<typename T>
+class vector2d : public vector<T> {
+  public:
+  using size_type = std::size_t;
+  using const_iterator = const T*;
+  using reference = T&;
+  using const_reference = const T&;
+  using vector<T>::data_;
+  using vector<T>::capacity_;
+  using vector<T>::size_;
+  // Constructors, destructors
+  vector2d() :  stride_(0), vector<T>() { }
+  vector2d(size_type n) : vector2d() { this->resize(n); }
+  vector2d(const_iterator begin, const_iterator end);
+  vector2d(std::initializer_list<T> init);
+
+  // 2D Element access
+  reference operator()(size_type outer_pos, size_type pos) { return data_[outer_pos * stride_ + pos]; }
+  const_reference operator()(size_type outer_pos, size_type pos) const { return data_[outer_pos * stride_ + pos]; }
+
+  // Stretching functions.
+  // The idea here is that you should call these on every row you want to add to the
+  // matrix first to determine which is longest, which is kept track of in the stride_
+  // field. We could also add a direct way of setting stride_
+  // down the line, but these stretching functions are useful for finding the material
+  // with the most nuclides, thermal tables, etc, without having to repeat the logic
+  // multiple times elsewhere.
+  void stretch(vector<T>& vect) {
+    if (vect.size() > stride_) {
+      stride_ = vect.size();
+    }
+  }
+  void stretch(xt::xtensor<T,1>& vect) {
+    if (vect.size() > stride_) {
+      stride_ = vect.size();
+    }
+  }
+
+  // Allocates a 2d matrix of dimension count x stride_
+  void resize2d(size_type count) {
+    count *= stride_;
+    this->reserve(count);
+    if (size_ < count) {
+      // Default insert new elements
+      for (size_type i = size_; i < count; ++i) {
+        new(data_ + i) T();
+      }
+    } else if (count < size_) {
+      // If new size is smaller, call destructor on erased elements
+      for (size_type i = count; i < size_; ++i) {
+        data_[i].~T();
+      }
+    }
+    size_ = count;
+  }
+
+  // Copies a row of data into the 2D matrix at row i
+  void copy_row(size_type i, vector<T>& row) {
+    for (int j = 0; j < row.size(); j++) {
+      data_[i * stride_ + j] = row[j];
+    }
+  }
+  void copy_row(size_type i, xt::xtensor<T,1>& row) {
+    for (int j = 0; j < row.size(); j++) {
+      data_[i * stride_ + j] = row[j];
+    }
+  }
+
+  protected:
+  size_type stride_;
+};
 
 } // namespace openmc
 

--- a/include/openmc/vector.h
+++ b/include/openmc/vector.h
@@ -418,12 +418,12 @@ class vector2d : public vector<T> {
   // down the line, but these stretching functions are useful for finding the material
   // with the most nuclides, thermal tables, etc, without having to repeat the logic
   // multiple times elsewhere.
-  void stretch(vector<T>& vect) {
+  void stretch(const vector<T>& vect) {
     if (vect.size() > stride_) {
       stride_ = vect.size();
     }
   }
-  void stretch(xt::xtensor<T,1>& vect) {
+  void stretch(const xt::xtensor<T,1>& vect) {
     if (vect.size() > stride_) {
       stride_ = vect.size();
     }
@@ -448,12 +448,12 @@ class vector2d : public vector<T> {
   }
 
   // Copies a row of data into the 2D matrix at row i
-  void copy_row(size_type i, vector<T>& row) {
+  void copy_row(size_type i, const vector<T>& row) {
     for (int j = 0; j < row.size(); j++) {
       data_[i * stride_ + j] = row[j];
     }
   }
-  void copy_row(size_type i, xt::xtensor<T,1>& row) {
+  void copy_row(size_type i, const xt::xtensor<T,1>& row) {
     for (int j = 0; j < row.size(); j++) {
       data_[i * stride_ + j] = row[j];
     }

--- a/include/openmc/vector.h
+++ b/include/openmc/vector.h
@@ -138,7 +138,7 @@ public:
     size_ = count;
   }
 
-  size_type footprint() { return size_ * sizeof(T); }
+  size_type nbytes() { return size_ * sizeof(T); }
 
   void reserve(size_type n) {
     if (n <= capacity_) return;
@@ -398,9 +398,6 @@ class vector2d : public vector<T> {
   using const_iterator = const T*;
   using reference = T&;
   using const_reference = const T&;
-  using vector<T>::data_;
-  using vector<T>::capacity_;
-  using vector<T>::size_;
   // Constructors, destructors
   vector2d() :  stride_(0), vector<T>() { }
   vector2d(size_type n) : vector2d() { this->resize(n); }
@@ -460,6 +457,9 @@ class vector2d : public vector<T> {
   }
 
   protected:
+  using vector<T>::data_;
+  using vector<T>::capacity_;
+  using vector<T>::size_;
   size_type stride_;
 };
 

--- a/src/device_alloc.cpp
+++ b/src/device_alloc.cpp
@@ -184,33 +184,99 @@ void move_read_only_data_to_device()
 
   // Materials /////////////////////////////////////////////////////////
 
-  std::cout << "Moving " << model::materials_size << " materials to device..." << std::endl;
-  int min = 99999;
-  int max = 0;
-  int n_over_200 = 0;
-  int n_under_200 = 0;
+  // Analyze fissionable materials
+  if (mpi::master) {
+    int min = 99999;
+    int max = 0;
+    int n_over_200 = 0;
+    int n_under_200 = 0;
+    for (int i = 0; i < model::materials_size; i++) {
+      if(model::materials[i].fissionable())
+      {
+        int num_nucs = model::materials[i].nuclide_.size();
+        if( num_nucs < min )
+          min = num_nucs;
+        if( num_nucs > max )
+          max = num_nucs;
+        if( num_nucs >= 200 )
+          n_over_200++;
+        else
+          n_under_200++;
+      }
+    }
+    std::cout << " Fissionable Material Statistics:" << std::endl <<
+      "   Max Nuclide Count: " << max << std::endl <<
+      "   Min Nuclide Count: " << min << std::endl <<
+      "   # Fissionable Materials with >= 200 Nuclides: " << n_over_200 << std::endl <<
+      "   # Fissionable Materials with  < 200 Nuclides: " << n_under_200 << std::endl;
+  }
+
+  // Determine size of inner dimension for serialized material vectors
+  for (int i = 0; i < model::materials_size; i++) {
+    auto& mat = model::materials[i];
+    model::materials_nuclide.stretch(mat.nuclide_);
+    model::materials_element.stretch(mat.element_);
+    model::materials_atom_density.stretch(mat.atom_density_);
+    model::materials_p0.stretch(mat.p0_);
+    model::materials_mat_nuclide_index.stretch(mat.mat_nuclide_index_);
+    model::materials_thermal_tables.stretch(mat.thermal_tables_);
+  }
+
+  // Allocate serialized material vectors
+  model::materials_nuclide.resize2d(model::materials_size);
+  model::materials_element.resize2d(model::materials_size);
+  model::materials_atom_density.resize2d(model::materials_size);
+  model::materials_p0.resize2d(model::materials_size);
+  model::materials_mat_nuclide_index.resize2d(model::materials_size);
+  model::materials_thermal_tables.resize2d(model::materials_size);
+
+  // Populate serialized material vectors
+  for (int i = 0; i < model::materials_size; i++) {
+    auto& mat = model::materials[i];
+    model::materials_nuclide.copy_row(i, mat.nuclide_);
+    model::materials_element.copy_row(i, mat.element_);
+    model::materials_atom_density.copy_row(i, mat.atom_density_);
+    model::materials_p0.copy_row(i, mat.p0_);
+    model::materials_mat_nuclide_index.copy_row(i, mat.mat_nuclide_index_);
+    model::materials_thermal_tables.copy_row(i, mat.thermal_tables_);
+  }
+
+  // Calculate and report memory usage (excluding any ttb_ data)
+  int n_bytes = model::materials_size * sizeof(Material);
+  n_bytes += model::materials_nuclide.footprint();
+  n_bytes += model::materials_element.footprint();
+  n_bytes += model::materials_atom_density.footprint();
+  n_bytes += model::materials_p0.footprint();
+  n_bytes += model::materials_mat_nuclide_index.footprint();
+  n_bytes += model::materials_thermal_tables.footprint();
+  if (mpi::master) {
+    std::cout << " Moving " << model::materials_size << " materials to device of total size: " << n_bytes * 1.0e-6 << " MB" << std::endl;
+  }
+
+  // Update top level global scalars to device
   #pragma omp target update to(model::materials_size)
+  #pragma omp target update to(model::materials_nuclide)
+  #pragma omp target update to(model::materials_element)
+  #pragma omp target update to(model::materials_atom_density)
+  #pragma omp target update to(model::materials_p0)
+  #pragma omp target update to(model::materials_mat_nuclide_index)
+  #pragma omp target update to(model::materials_thermal_tables)
+
+  // Map top level material array to device
   #pragma omp target enter data map(to: model::materials[:model::materials_size])
+
+  // Map ttb_ field arrays, if needed
   for (int i = 0; i < model::materials_size; i++) {
     model::materials[i].copy_to_device();
-    if(model::materials[i].fissionable())
-    {
-      int num_nucs = model::materials[i].nuclide_.size();
-      if( num_nucs < min )
-        min = num_nucs;
-      if( num_nucs > max )
-       max = num_nucs;
-     if( num_nucs >= 200 )
-       n_over_200++;
-     else
-       n_under_200++;
-    }
   }
-  std::cout << "Fissionable Material Statistics:" << std::endl <<
-  " Max Nuclide Count: " << max << std::endl <<
-  " Min Nuclide Count: " << min << std::endl <<
-  " # Fissionable Materials with >= 200 Nuclides: " << n_over_200 << std::endl <<
-  " # Fissionable Materials with  < 200 Nuclides: " << n_under_200 << std::endl;
+
+  // Map serialized material vectors to device
+  model::materials_nuclide.copy_to_device();
+  model::materials_element.copy_to_device();
+  model::materials_atom_density.copy_to_device();
+  model::materials_p0.copy_to_device();
+  model::materials_mat_nuclide_index.copy_to_device();
+  model::materials_thermal_tables.copy_to_device();
 
   // Source Bank ///////////////////////////////////////////////////////
 

--- a/src/device_alloc.cpp
+++ b/src/device_alloc.cpp
@@ -213,7 +213,7 @@ void move_read_only_data_to_device()
 
   // Determine size of inner dimension for serialized material vectors
   for (int i = 0; i < model::materials_size; i++) {
-    auto& mat = model::materials[i];
+    const auto& mat = model::materials[i];
     model::materials_nuclide.stretch(mat.nuclide_);
     model::materials_element.stretch(mat.element_);
     model::materials_atom_density.stretch(mat.atom_density_);

--- a/src/device_alloc.cpp
+++ b/src/device_alloc.cpp
@@ -243,12 +243,12 @@ void move_read_only_data_to_device()
 
   // Calculate and report memory usage (excluding any ttb_ data)
   int n_bytes = model::materials_size * sizeof(Material);
-  n_bytes += model::materials_nuclide.footprint();
-  n_bytes += model::materials_element.footprint();
-  n_bytes += model::materials_atom_density.footprint();
-  n_bytes += model::materials_p0.footprint();
-  n_bytes += model::materials_mat_nuclide_index.footprint();
-  n_bytes += model::materials_thermal_tables.footprint();
+  n_bytes += model::materials_nuclide.nbytes();
+  n_bytes += model::materials_element.nbytes();
+  n_bytes += model::materials_atom_density.nbytes();
+  n_bytes += model::materials_p0.nbytes();
+  n_bytes += model::materials_mat_nuclide_index.nbytes();
+  n_bytes += model::materials_thermal_tables.nbytes();
   if (mpi::master) {
     std::cout << " Moving " << model::materials_size << " materials to device of total size: " << n_bytes * 1.0e-6 << " MB" << std::endl;
   }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -41,6 +41,12 @@ namespace model {
 std::unordered_map<int32_t, int32_t> material_map;
 Material* materials;
 uint64_t materials_size;
+vector2d<int> materials_nuclide;
+vector2d<int> materials_element;
+vector2d<double> materials_atom_density;
+vector2d<int> materials_p0;
+vector2d<int> materials_mat_nuclide_index;
+vector2d<ThermalTable> materials_thermal_tables;
 
 } // namespace model
 
@@ -1067,24 +1073,11 @@ void Material::add_nuclide(const std::string& name, double density)
 
 void Material::copy_to_device()
 {
-  nuclide_.copy_to_device();
-  element_.copy_to_device();
-  mat_nuclide_index_.copy_to_device();
-  p0_.copy_to_device();
-  device_atom_density_ = atom_density_.data();
-  #pragma omp target enter data map(to: device_atom_density_[:atom_density_.size()])
-  thermal_tables_.copy_to_device();
   ttb_.copy_to_device();
 }
 
 void Material::release_from_device()
 {
-  nuclide_.release_device();
-  element_.release_device();
-  mat_nuclide_index_.release_device();
-  p0_.release_device();
-  #pragma omp target exit data map(release: device_atom_density_[:atom_density_.size()])
-  thermal_tables_.release_device();
   ttb_.release_from_device();
 }
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -778,7 +778,7 @@ void Material::calculate_neutron_xs(Particle& p, bool need_depletion_rx) const
   for (int i = 0; i < nuclide_.size(); ++i) {
 
     // Determine microscopic cross sections for this nuclide
-    int i_nuclide = nuclide_[i];
+    int i_nuclide = nuclide(i);
 
     // Perform microscopic XS lookup
     NuclideMicroXS nuclide_micro = data::nuclides[i_nuclide].calculate_xs(i_grid, p, need_depletion_rx);
@@ -789,7 +789,7 @@ void Material::calculate_neutron_xs(Particle& p, bool need_depletion_rx) const
     #endif
 
     // Get atom density of nuclide in material
-    double atom_density = device_atom_density_[i];
+    double atom_density = this->atom_density(i);
 
     // Accumulate this nuclide's contribution to the local macro XS variable
     macro.total      += atom_density * nuclide_micro.total;
@@ -818,7 +818,7 @@ void Material::calculate_photon_xs(Particle& p) const
     // CALCULATE MICROSCOPIC CROSS SECTION
 
     // Determine microscopic cross sections for this nuclide
-    int i_element = element_[i];
+    int i_element = element(i);
 
     // Calculate microscopic cross section for this nuclide
     const auto& micro {p.photon_xs_[i_element]};
@@ -830,7 +830,7 @@ void Material::calculate_photon_xs(Particle& p) const
     // ADD TO MACROSCOPIC CROSS SECTION
 
     // Copy atom density of nuclide in material
-    double atom_density = device_atom_density_[i];
+    double atom_density = this->atom_density(i);
 
     // Add contributions to material macroscopic cross sections
     p.macro_xs_.total += atom_density * micro.total;

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -641,7 +641,7 @@ NuclideMicroXS Nuclide::calculate_xs(int i_log_union, Particle& p, bool need_dep
 
   const auto& mat = model::materials[p.material_];
   for (int s = 0; s < mat.thermal_tables_.size(); s++) {
-    const auto& sab {mat.thermal_tables_[s]};
+    const auto& sab {mat.thermal_tables(s)};
     if (index_ == sab.index_nuclide) {
       // Get index in sab_tables
       i_sab = sab.index_table;

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -484,14 +484,14 @@ int sample_nuclide(Particle& p)
 
   double prob = 0.0;
   for (int i = 0; i < n; ++i) {
-    int i_nuclide = mat.nuclide_[i];
+    int i_nuclide = mat.nuclide(i);
 
     // Lookup micro XS (no depletion XS data is needed for collisions)
     bool need_depletion_rx = false;
     NuclideMicroXS xs = data::nuclides[i_nuclide].calculate_xs(i_grid, p, need_depletion_rx);
     
     // Get atom density
-    double atom_density = mat.device_atom_density_[i];
+    double atom_density = mat.atom_density(i);
 
     // Increment probability to compare to cutoff
     prob += atom_density * xs.total;
@@ -523,8 +523,8 @@ int sample_nuclide(Particle& p)
   double prob = 0.0;
   for (int i = 0; i < n; ++i) {
     // Get atom density
-    int i_nuclide = mat.nuclide_[i];
-    double atom_density = mat.device_atom_density_[i];
+    int i_nuclide = mat.nuclide(i);
+    double atom_density = mat.atom_density(i);
 
     // Increment probability to compare to cutoff
     prob += atom_density * p.neutron_xs_[i_nuclide].total;
@@ -551,8 +551,8 @@ int sample_element(Particle& p)
   double prob = 0.0;
   for (int i = 0; i < mat.element_.size(); ++i) {
     // Find atom density
-    int i_element = mat.element_[i];
-    double atom_density = mat.device_atom_density_[i];
+    int i_element = mat.element(i);
+    double atom_density = mat.atom_density(i);
 
     // Determine microscopic cross section
     double sigma = atom_density * p.photon_xs_[i_element].total;
@@ -561,7 +561,7 @@ int sample_element(Particle& p)
     prob += sigma;
     if (prob > cutoff) {
       // Save which nuclide particle had collision with for tally purpose
-      p.event_nuclide_ = mat.nuclide_[i];
+      p.event_nuclide_ = mat.nuclide(i);
 
       return i_element;
     }
@@ -772,8 +772,8 @@ void scatter(Particle& p, int i_nuclide)
   // Sample new outgoing angle for isotropic-in-lab scattering
   const auto& mat {model::materials[p.material_]};
   if (!mat.p0_.empty()) {
-    int i_nuc_mat = mat.mat_nuclide_index_[i_nuclide];
-    if (mat.p0_[i_nuc_mat]) {
+    int i_nuc_mat = mat.mat_nuclide_index(i_nuclide);
+    if (mat.p0(i_nuc_mat)) {
       // Sample isotropic-in-lab outgoing direction
       double mu = 2.0*prn(p.current_seed()) - 1.0;
       double phi = 2.0*PI*prn(p.current_seed());

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -2407,9 +2407,9 @@ score_tracklength_tally(Particle& p, double distance, bool need_depletion_rx)
         NuclideMicroXS micro;
         if (i_nuclide >= 0) {
           if (p.material_ != MATERIAL_VOID) {
-            auto j = model::materials[p.material_].mat_nuclide_index_[i_nuclide];
+            auto j = model::materials[p.material_].mat_nuclide_index(i_nuclide);
             if (j == C_NONE) continue;
-            atom_density = model::materials[p.material_].device_atom_density_[j];
+            atom_density = model::materials[p.material_].atom_density(j);
             #ifdef NO_MICRO_XS_CACHE
             micro = data::nuclides[i_nuclide].calculate_xs(i_grid, p, need_depletion_rx);
             #else


### PR DESCRIPTION
This PR serializes materials into global arrays. The global arrays are implemented in the form of a new class, `vector2d<T>`. See the writeup of PR #8 for more info.