### PR TITLE
Sorting of NonFuel XS Lookup Queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,8 +132,8 @@ if(coverage)
   list(APPEND ldflags --coverage)
 endif()
 if(sycl_sort)
-  list(APPEND cxxflags -fsycl -D_GLIBCXX_USE_TBB_PAR_BACKEND=0)
-  list(APPEND ldflags -fsycl -D_GLIBCXX_USE_TBB_PAR_BACKEND=0)
+  list(APPEND cxxflags -fsycl -D_PSTL_PAR_BACKEND_SERIAL=1 -DPSTL_USE_PARALLEL_POLICIES=0 -D_GLIBCXX_USE_TBB_PAR_BACKEND=0)
+  list(APPEND ldflags -fsycl -D_PSTL_PAR_BACKEND_SERIAL=1 -DPSTL_USE_PARALLEL_POLICIES=0 -D_GLIBCXX_USE_TBB_PAR_BACKEND=0)
 endif()
 
 # Show flags being used
@@ -464,12 +464,11 @@ target_compile_options(openmc PRIVATE ${cxxflags})
 target_include_directories(openmc PRIVATE ${CMAKE_BINARY_DIR}/include)
 target_link_libraries(openmc libopenmc)
 
-# Ensure C++14 standard is used. Starting with CMake 3.8, another way this could
-# be done is using the cxx_std_14 compiler feature.
+# Ensure C++17 standard is used (required for Intel OneDPL on-device sorting)
 set_target_properties(
   #openmc libopenmc faddeeva
     openmc libopenmc
-    PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
+    PROPERTIES CXX_STANDARD 17 CXX_EXTENSIONS OFF)
 
 #===============================================================================
 # Python package

--- a/include/openmc/event.h
+++ b/include/openmc/event.h
@@ -22,17 +22,16 @@ namespace openmc {
 // result in any benefits if not enough particles are present for them to achieve
 // consistent locality improvements. 
 struct EventQueueItem{
-  int idx;         //!< particle index in event-based particle buffer
-  //Particle::Type type; //!< particle type
-  //int64_t material;    //!< material that particle is in
-  //double E;            //!< particle energy
-  float E;            //!< particle energy
-  //int64_t id;
+  int idx;      //!< particle index in event-based particle buffer
+  int material; //!< material that particle is in
+  float E;      //!< particle energy
 
   // Constructors
   EventQueueItem() = default;
   EventQueueItem(double energy, int buffer_idx) :
-    idx(buffer_idx), E(static_cast<float>(energy)) {}
+    idx(buffer_idx), material(0), E(static_cast<float>(energy)) {}
+  EventQueueItem(double energy, int mat, int buffer_idx) :
+    idx(buffer_idx), material(mat), E(static_cast<float>(energy)) {}
 
   // Compare by particle type, then by material type (4.5% fuel/7.0% fuel/cladding/etc),
   // then by energy.
@@ -46,15 +45,21 @@ struct EventQueueItem{
   #endif
   bool operator<(const EventQueueItem& rhs) const
   {
-    //return std::tie(type, material, E) < std::tie(rhs.type, rhs.material, rhs.E);
-    return E < rhs.E;
+    if (material == rhs.material) {
+      return E < rhs.E;
+    } else {
+      return material < rhs.material;
+    }
   }
   
   // This is needed by the implementation of parallel quicksort
   bool operator>(const EventQueueItem& rhs) const
   {
-    //return std::tie(type, material, E) < std::tie(rhs.type, rhs.material, rhs.E);
-    return E > rhs.E;
+    if (material == rhs.material) {
+      return E > rhs.E;
+    } else {
+      return material > rhs.material;
+    }
   }
 };
 

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -126,7 +126,7 @@ void dispatch_xs_event(int buffer_idx)
   if (needs_lookup) {
     // If a lookup is needed, dispatch to fuel vs. non-fuel lookup queue
     if (!model::materials[p.material_].fissionable_) {
-      simulation::calculate_nonfuel_xs_queue.thread_safe_append({p.E_, buffer_idx});
+      simulation::calculate_nonfuel_xs_queue.thread_safe_append({p.E_, p.material_, buffer_idx});
     } else {
       simulation::calculate_fuel_xs_queue.thread_safe_append({p.E_, buffer_idx});
     }
@@ -176,6 +176,9 @@ bool depletion_rx_check()
 
 void process_calculate_xs_events_nonfuel()
 {
+  // Sort non fuel lookup queue by material and energy
+  sort_queue(simulation::calculate_nonfuel_xs_queue);
+
   simulation::time_event_calculate_xs.start();
   simulation::time_event_calculate_xs_nonfuel.start();
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -454,7 +454,7 @@ void print_runtime()
     show_time("XS lookups (Total)", time_event_calculate_xs.elapsed(), 2);
     show_time("XS lookups (Fuel)", time_event_calculate_xs_fuel.elapsed(), 2);
     show_time("XS lookups (Non-Fuel)", time_event_calculate_xs_nonfuel.elapsed(), 2);
-    show_time("Fuel energy sorting", time_event_sort.elapsed(), 2);
+    show_time("XS queue sorting", time_event_sort.elapsed(), 2);
     show_time("Avg. time per sort", time_event_sort.elapsed() / sort_counter, 2);
     show_time("Advancing", time_event_advance_particle.elapsed(), 2);
     show_time("Tallying", time_event_tally.elapsed(), 2);


### PR DESCRIPTION
While we have been sorting fuel XS lookup events by energy for a long time, this PR introduces sorting (by material, then energy) for the non-fuel lookup queue as well. See PR #8 for more details.

For an A100 with a single MPI rank and 8 million particles in-flight, in terms of kparticles/sec, this PR has the following effect:

  | Old | This PR
-- | -- | --
HM Large Inactive | 356 | 359
SMR Active | 161 | 177



