### PR TITLE
Backport properties export/import

### DIFF
--- a/docs/source/io_formats/index.rst
+++ b/docs/source/io_formats/index.rst
@@ -45,6 +45,7 @@ Output Files
    statepoint
    source
    summary
+   properties
    depletion_results
    particle_restart
    track

--- a/docs/source/io_formats/properties.rst
+++ b/docs/source/io_formats/properties.rst
@@ -1,0 +1,36 @@
+.. _io_properties:
+
+======================
+Properties File Format
+======================
+
+The current version of the properties file format is 1.0.
+
+**/**
+
+:Attributes: - **filetype** (*char[]*) -- String indicating the type of file.
+             - **version** (*int[2]*) -- Major and minor version of the
+               statepoint file format.
+             - **openmc_version** (*int[3]*) -- Major, minor, and release
+               version number for OpenMC.
+             - **git_sha1** (*char[40]*) -- Git commit SHA-1 hash.
+             - **date_and_time** (*char[]*) -- Date and time the summary was
+               written.
+             - **path** (*char[]*) -- Path to directory containing input files.
+
+**/geometry/**
+
+:Attributes: - **n_cells** (*int*) -- Number of cells in the problem.
+
+**/geometry/cells/cell <uid>/**
+
+:Datasets: - **temperature** (*double[]*) -- Temperature of the cell in [K].
+
+**/materials/**
+
+:Attributes: - **n_materials** (*int*) -- Number of materials in the problem.
+
+**/materials/material <uid>/**
+
+:Attributes: - **atom_density** (*double*) -- Total density in [atom/b-cm].
+             - **mass_density** (*double*) -- Total density in [g/cm^3].

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -15,6 +15,7 @@ extern "C" {
   int openmc_cell_get_id(int32_t index, int32_t* id);
   int openmc_cell_get_temperature(int32_t index, const int32_t* instance, double* T);
   int openmc_cell_get_name(int32_t index, const char** name);
+  int openmc_cell_get_num_instances(int32_t index, int32_t* num_instances);
   int openmc_cell_set_name(int32_t index, const char* name);
   int openmc_cell_set_fill(int32_t index, int type, int32_t n, const int32_t* indices);
   int openmc_cell_set_id(int32_t index, int32_t id);
@@ -172,6 +173,16 @@ extern "C" {
   //! \return number of inner iterations required to reach convergence
   extern "C" int openmc_run_linsolver(const double* A_data, const double* b,
                                       double* x, double tol);
+
+  //! Export physical properties for model
+  //! \param[in] filename Filename to write to
+  //! \return Error code
+  int openmc_properties_export(const char* filename);
+
+  //! Import physical properties for model
+  //! \param[in] filename Filename to read from
+  // \return Error code
+  int openmc_properties_import(const char* filename);
 
   // Error codes
   extern int OPENMC_E_UNASSIGNED;

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -139,6 +139,14 @@ public:
   //! \param group_id An HDF5 group id.
   void to_hdf5(hid_t group_id) const;
 
+  //! Export physical properties to HDF5
+  //! \param[in] group  HDF5 group to read from
+  void export_properties_hdf5(hid_t group) const;
+
+  //! Import physical properties from HDF5
+  //! \param[in] group  HDF5 group to write to
+  void import_properties_hdf5(hid_t group);
+
   //! Get the BoundingBox for this cell.
   BoundingBox bounding_box() const;
 

--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -31,6 +31,7 @@ constexpr std::array<int, 2> VERSION_SUMMARY {6, 0};
 constexpr std::array<int, 2> VERSION_VOLUME {1, 0};
 constexpr std::array<int, 2> VERSION_VOXEL {2, 0};
 constexpr std::array<int, 2> VERSION_MGXS_LIBRARY {1, 0};
+constexpr std::array<int, 2> VERSION_PROPERTIES {1, 0};
 
 // ============================================================================
 // ADJUSTABLE PARAMETERS

--- a/include/openmc/hdf5_interface.h
+++ b/include/openmc/hdf5_interface.h
@@ -53,7 +53,7 @@ inline hid_t create_group(hid_t parent_id, const std::stringstream& name)
 
 
 hid_t file_open(const std::string& filename, char mode, bool parallel=false);
-
+hid_t open_group(hid_t group_id, const std::string& name);
 void write_string(hid_t group_id, const char* name, const std::string& buffer,
                   bool indep);
 

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -76,6 +76,14 @@ public:
   //! Write material data to HDF5
   void to_hdf5(hid_t group) const;
 
+  //! Export physical properties to HDF5
+  //! \param[in] group  HDF5 group to write to
+  void export_properties_hdf5(hid_t group) const;
+
+  //! Import physical properties from HDF5
+  //! \param[in] group  HDF5 group to read from
+  void import_properties_hdf5(hid_t group);
+
   //! Add nuclide to the material
   //
   //! \param[in] nuclide Name of the nuclide

--- a/openmc/lib/cell.py
+++ b/openmc/lib/cell.py
@@ -25,6 +25,9 @@ _dll.openmc_cell_get_fill.argtypes = [
     c_int32, POINTER(c_int), POINTER(POINTER(c_int32)), POINTER(c_int32)]
 _dll.openmc_cell_get_fill.restype = c_int
 _dll.openmc_cell_get_fill.errcheck = _error_handler
+_dll.openmc_cell_get_num_instances.argtypes = [c_int32, POINTER(c_int32)]
+_dll.openmc_cell_get_num_instances.restype = c_int
+_dll.openmc_cell_get_num_instances.errcheck = _error_handler
 _dll.openmc_cell_get_temperature.argtypes = [
     c_int32, POINTER(c_int32), POINTER(c_double)]
 _dll.openmc_cell_get_temperature.restype = c_int
@@ -78,6 +81,14 @@ class Cell(_FortranObjectWithID):
     ----------
     id : int
         ID of the cell
+    fill : openmc.lib.Material or list of openmc.lib.Material
+        Indicates what the region of space is filled with
+    name : str
+        Name of the cell
+    num_instances : int
+        Number of unique cell instances
+    bounding_box : 2-tuple of numpy.ndarray
+        Lower-left and upper-right coordinates of bounding box
 
     """
     __instances = WeakValueDictionary()
@@ -159,6 +170,12 @@ class Cell(_FortranObjectWithID):
             indices = (c_int32*1)(-1)
             _dll.openmc_cell_set_fill(self._index, 0, 1, indices)
 
+    @property
+    def num_instances(self):
+        n = c_int32()
+        _dll.openmc_cell_get_num_instances(self._index, n)
+        return n.value
+
     def get_temperature(self, instance=None):
         """Get the temperature of a cell
 
@@ -210,6 +227,7 @@ class Cell(_FortranObjectWithID):
         urc[urc == -inf] = -np.inf
 
         return llc, urc
+
 
 class _CellMapping(Mapping):
     def __getitem__(self, key):

--- a/openmc/lib/material.py
+++ b/openmc/lib/material.py
@@ -175,15 +175,6 @@ class Material(_FortranObjectWithID):
         return nuclides
 
     @property
-    def density(self):
-      density = c_double()
-      try:
-          _dll.openmc_material_get_density(self._index, density)
-      except OpenMCError:
-          return None
-      return density.value
-
-    @property
     def densities(self):
         return self._get_densities()[1]
 
@@ -223,6 +214,29 @@ class Material(_FortranObjectWithID):
 
         """
         _dll.openmc_material_add_nuclide(self._index, name.encode(), density)
+
+    def get_density(self, units='atom/b-cm'):
+        """Get density of a material.
+
+        Parameters
+        ----------
+        units : {'atom/b-cm', 'g/cm3'}
+            Units for density
+
+        Returns
+        -------
+        float
+            Density in requested units
+
+        """
+        if units == 'atom/b-cm':
+            return self.densities.sum()
+        elif units == 'g/cm3':
+            density = c_double()
+            _dll.openmc_material_get_density(self._index, density)
+            return density.value
+        else:
+            raise ValueError("Units must be 'atom/b-cm' or 'g/cm3'")
 
     def set_density(self, density, units='atom/b-cm'):
         """Set density of a material.

--- a/openmc/lib/plot.py
+++ b/openmc/lib/plot.py
@@ -228,11 +228,11 @@ def id_map(plot):
     Returns
     -------
     id_map : numpy.ndarray
-        A NumPy array with shape (vertical pixels, horizontal pixels, 2) of
+        A NumPy array with shape (vertical pixels, horizontal pixels, 3) of
         OpenMC property ids with dtype int32
 
     """
-    img_data = np.zeros((plot.v_res, plot.h_res, 2),
+    img_data = np.zeros((plot.v_res, plot.h_res, 3),
                         dtype=np.dtype('int32'))
     _dll.openmc_id_map(plot, img_data.ctypes.data_as(POINTER(c_int32)))
     return img_data

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -315,6 +315,46 @@ Cell::set_temperature(double T, int32_t instance, bool set_contained)
   }
 }
 
+void Cell::export_properties_hdf5(hid_t group) const
+{
+  // Create a group for this cell.
+  auto cell_group = create_group(group, fmt::format("cell {}", id_));
+
+  // Write temperature in [K] for one or more cell instances
+  vector<double> temps;
+  for (auto sqrtkT_val : sqrtkT_)
+    temps.push_back(sqrtkT_val * sqrtkT_val / K_BOLTZMANN);
+  write_dataset(cell_group, "temperature", temps);
+
+  close_group(cell_group);
+}
+
+void Cell::import_properties_hdf5(hid_t group)
+{
+  auto cell_group = open_group(group, fmt::format("cell {}", id_));
+
+  // Read temperatures from file
+  vector<double> temps;
+  read_dataset(cell_group, "temperature", temps);
+
+  // Ensure number of temperatures makes sense
+  auto n_temps = temps.size();
+  if (n_temps > 1 && n_temps != n_instances_) {
+    throw std::runtime_error(fmt::format(
+      "Number of temperatures for cell {} doesn't match number of instances",
+      id_));
+  }
+
+  // Modify temperatures for the cell
+  sqrtkT_.clear();
+  sqrtkT_.resize(temps.size());
+  for (gsl::index i = 0; i < temps.size(); ++i) {
+    this->set_temperature(temps[i], i);
+  }
+
+  close_group(cell_group);
+}
+
 void Cell::allocate_on_device()
 {
   // Functionality moved to copy_to_device()
@@ -1400,6 +1440,18 @@ openmc_cell_set_id(int32_t index, int32_t id)
     set_errmsg("Index in cells array is out of bounds.");
     return OPENMC_E_OUT_OF_BOUNDS;
   }
+}
+
+//! Get the number of instances of the requested cell
+extern "C" int openmc_cell_get_num_instances(
+  int32_t index, int32_t* num_instances)
+{
+  if (index < 0 || index >= model::cells.size()) {
+    set_errmsg("Index in cells array is out of bounds.");
+    return OPENMC_E_OUT_OF_BOUNDS;
+  }
+  *num_instances = model::cells[index].n_instances_;
+  return 0;
 }
 
 //! Extend the cells array by n elements

--- a/src/hdf5_interface.cpp
+++ b/src/hdf5_interface.cpp
@@ -226,6 +226,11 @@ file_open(const std::string& filename, char mode, bool parallel)
   return file_open(filename.c_str(), mode, parallel);
 }
 
+hid_t open_group(hid_t group_id, const std::string& name)
+{
+  return open_group(group_id, name.c_str());
+}
+
 void file_close(hid_t file_id)
 {
   H5Fclose(file_id);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -776,7 +776,7 @@ void Material::calculate_neutron_xs(Particle& p, bool need_depletion_rx) const
 
     // Perform microscopic XS lookup
     NuclideMicroXS nuclide_micro = data::nuclides[i_nuclide].calculate_xs(i_grid, p, need_depletion_rx);
-    
+
     // If using a micro XS cache, store the result to the particle's cache
     #ifndef NO_MICRO_XS_CACHE
     p.neutron_xs_[i_nuclide] = nuclide_micro;
@@ -790,7 +790,7 @@ void Material::calculate_neutron_xs(Particle& p, bool need_depletion_rx) const
     macro.absorption += atom_density * nuclide_micro.absorption;
     macro.fission    += atom_density * nuclide_micro.fission;
     macro.nu_fission += atom_density * nuclide_micro.nu_fission;
-    for (int r = 0; r < DEPLETION_RX_SIZE; r++) 
+    for (int r = 0; r < DEPLETION_RX_SIZE; r++)
       macro.reaction[r] += atom_density * nuclide_micro.reaction[r];
   }
 
@@ -1020,6 +1020,23 @@ void Material::to_hdf5(hid_t group) const
     write_dataset(material_group, "sab_names", sab_names);
   }
 
+  close_group(material_group);
+}
+
+void Material::export_properties_hdf5(hid_t group) const
+{
+  hid_t material_group = create_group(group, "material " + std::to_string(id_));
+  write_attribute(material_group, "atom_density", density_);
+  write_attribute(material_group, "mass_density", density_gpcc_);
+  close_group(material_group);
+}
+
+void Material::import_properties_hdf5(hid_t group)
+{
+  hid_t material_group = open_group(group, "material " + std::to_string(id_));
+  double density;
+  read_attribute(material_group, "atom_density", density);
+  this->set_density(density, "atom/b-cm");
   close_group(material_group);
 }
 

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -1,9 +1,14 @@
 #include "openmc/summary.h"
 
+#include <fmt/core.h>
+
+#include "openmc/capi.h"
 #include "openmc/cell.h"
+#include "openmc/file_utils.h"
 #include "openmc/hdf5_interface.h"
 #include "openmc/lattice.h"
 #include "openmc/material.h"
+#include "openmc/message_passing.h"
 #include "openmc/mgxs_interface.h"
 #include "openmc/nuclide.h"
 #include "openmc/output.h"
@@ -132,6 +137,130 @@ void write_materials(hid_t file)
     mat.to_hdf5(materials_group);
   }
   close_group(materials_group);
+}
+
+//==============================================================================
+// C API
+//==============================================================================
+
+extern "C" int openmc_properties_export(const char* filename)
+{
+  // Only write from master process
+  if (!mpi::master)
+    return 0;
+
+  // Set a default filename if none was passed
+  std::string name = filename ? filename : "properties.h5";
+
+  // Display output message
+  auto msg = fmt::format("Exporting properties to {}...", name);
+  write_message(msg, 5);
+
+  // Create a new file using default properties.
+  hid_t file = file_open(name, 'w');
+
+  // Write metadata
+  write_attribute(file, "filetype", "properties");
+  write_attribute(file, "version", VERSION_STATEPOINT);
+  write_attribute(file, "openmc_version", VERSION);
+#ifdef GIT_SHA1
+  write_attribute(file, "git_sha1", GIT_SHA1);
+#endif
+  write_attribute(file, "date_and_time", time_stamp());
+  write_attribute(file, "path", settings::path_input);
+
+  // Write cell properties
+  auto geom_group = create_group(file, "geometry");
+  write_attribute(geom_group, "n_cells", model::cells.size());
+  auto cells_group = create_group(geom_group, "cells");
+  for (const auto& c : model::cells) {
+    c.export_properties_hdf5(cells_group);
+  }
+  close_group(cells_group);
+  close_group(geom_group);
+
+  // Write material properties
+  hid_t materials_group = create_group(file, "materials");
+  write_attribute(materials_group, "n_materials", model::materials_size);
+  for (int i = 0; i < model::materials_size; i++) {
+    const auto& mat = model::materials[i];
+    mat.export_properties_hdf5(materials_group);
+  }
+  close_group(materials_group);
+
+  // Terminate access to the file.
+  file_close(file);
+  return 0;
+}
+
+extern "C" int openmc_properties_import(const char* filename)
+{
+  // Display output message
+  auto msg = fmt::format("Importing properties from {}...", filename);
+  write_message(msg, 5);
+
+  // Create a new file using default properties.
+  if (!file_exists(filename)) {
+    set_errmsg(fmt::format("File '{}' does not exist.", filename));
+    return OPENMC_E_INVALID_ARGUMENT;
+  }
+  hid_t file = file_open(filename, 'r');
+
+  // Ensure the filetype is correct
+  std::string filetype;
+  read_attribute(file, "filetype", filetype);
+  if (filetype != "properties") {
+    file_close(file);
+    set_errmsg(fmt::format("File '{}' is not a properties file.", filename));
+    return OPENMC_E_INVALID_ARGUMENT;
+  }
+
+  // Make sure number of cells matches
+  auto geom_group = open_group(file, "geometry");
+  int32_t n;
+  read_attribute(geom_group, "n_cells", n);
+  if (n != openmc::model::cells.size()) {
+    close_group(geom_group);
+    file_close(file);
+    set_errmsg(fmt::format(
+      "Number of cells in {} doesn't match current model.", filename));
+    return OPENMC_E_GEOMETRY;
+  }
+
+  // Read cell properties
+  auto cells_group = open_group(geom_group, "cells");
+  try {
+    for (auto& c : model::cells) {
+      c.import_properties_hdf5(cells_group);
+    }
+  } catch (const std::exception& e) {
+    set_errmsg(e.what());
+    return OPENMC_E_UNASSIGNED;
+  }
+  close_group(cells_group);
+  close_group(geom_group);
+
+  // Make sure number of cells matches
+  auto materials_group = open_group(file, "materials");
+  read_attribute(materials_group, "n_materials", n);
+  if (n != openmc::model::materials_size) {
+    close_group(materials_group);
+    file_close(file);
+    set_errmsg(fmt::format(
+      "Number of materials in {} doesn't match current model.", filename));
+    return OPENMC_E_GEOMETRY;
+  }
+
+  // Read material properties
+  for (int i = 0; i < model::materials_size; i++) {
+    auto& mat = model::materials[i];
+    mat.import_properties_hdf5(materials_group);
+  }
+  close_group(materials_group);
+
+  // Terminate access to the file.
+  file_close(file);
+  return 0;
 }
 
 } // namespace openmc

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -1,0 +1,34 @@
+import pytest
+import openmc
+import openmc.lib
+
+
+def test_import_properties(run_in_tmpdir, mpi_intracomm):
+    """Test importing properties on the Model class """
+
+    # Create PWR pin cell model and write XML files
+    openmc.reset_auto_ids()
+    model = openmc.examples.pwr_pin_cell()
+    model.export_to_xml()
+
+    # Change fuel temperature and density and export properties
+    openmc.lib.init(intracomm=mpi_intracomm)
+    cell = openmc.lib.cells[1]
+    cell.set_temperature(600.0)
+    cell.fill.set_density(5.0, 'g/cm3')
+    openmc.lib.export_properties()
+    openmc.lib.finalize()
+
+    # Import properties to existing model and re-export to new directory
+    model.import_properties("properties.h5")
+    model.export_to_xml("with_properties")
+
+    # Load model with properties and confirm temperature/density has been changed
+    model_with_properties = openmc.Model.from_xml(
+        'with_properties/geometry.xml',
+        'with_properties/materials.xml',
+        'with_properties/settings.xml'
+    )
+    cell = model_with_properties.geometry.get_all_cells()[1]
+    assert cell.temperature == [600.0]
+    assert cell.fill.get_mass_density() == pytest.approx(5.0)


### PR DESCRIPTION
I had a look through [ENRICO](https://github.com/enrico-dev/enrico) to see which OpenMC C API functions that are used for coupling are present on our `openmp-target-offload` branch. Everything was present _except_ for `openmc_properties_export`, which was originally implemented in openmc-dev/openmc#1852. This PR backports that feature to our `openmp-target-offload` branch so that we should be able to seamlessly hook it up to ENRICO.