### PR TITLE
Correction to size limit enforcement for Filter Match array

### DIFF
--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -52,6 +52,8 @@ public:
   const vector<int32_t>& filters() const {return filters_;}
 
   int32_t filters(int i) const {return filters_[i];}
+  
+  int32_t n_filters() const {return filters_.size();}
 
   void set_filters(gsl::span<Filter*> filters);
 

--- a/src/device_alloc.cpp
+++ b/src/device_alloc.cpp
@@ -34,6 +34,7 @@ void enforce_assumptions()
   assert(model::tally_derivs.size() <= FLUX_DERIVS_SIZE);
   for (auto i = 0; i < model::tallies_size; i++) {
     assert(model::tallies[i].n_filters() <= FILTER_MATCHES_SIZE);
+    assert(model::tallies[i].estimator_ == TallyEstimator::TRACKLENGTH && "Analog and collision tallies not yet supported on device.");
   }
   assert(model::n_coord_levels <= COORD_SIZE);
   #ifndef NO_MICRO_XS_CACHE

--- a/src/device_alloc.cpp
+++ b/src/device_alloc.cpp
@@ -32,7 +32,9 @@ void enforce_assumptions()
 
   // Assertions made when initializing particles
   assert(model::tally_derivs.size() <= FLUX_DERIVS_SIZE);
-  assert(model::n_tally_filters <= FILTER_MATCHES_SIZE);
+  for (auto i = 0; i < model::tallies_size; i++) {
+    assert(model::tallies[i].n_filters() <= FILTER_MATCHES_SIZE);
+  }
   assert(model::n_coord_levels <= COORD_SIZE);
   #ifndef NO_MICRO_XS_CACHE
   assert(data::nuclides_size <= NEUTRON_XS_SIZE);

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -29,8 +29,9 @@ FilterBinIter::FilterBinIter(const Tally& tally, Particle& p)
 {
   // Find all valid bins in each relevant filter if they have not already been
   // found for this event.
-  for (auto i_filt : tally_.filters()) {
-    auto& match {filter_matches_[i_filt]};
+  for (int filt = 0; filt < tally_.n_filters(); filt++) {
+    auto i_filt = tally_.filters(filt);
+    auto& match {filter_matches_[filt]};
     if (!match.bins_present_) {
       match.bins_weights_length_ = 0;
       model::tally_filters[i_filt].get_all_bins(p, tally_.estimator_, match);
@@ -62,8 +63,9 @@ FilterBinIter::FilterBinIter(const Tally& tally, bool end,
     return;
   }
 
-  for (auto i_filt : tally_.filters()) {
-    auto& match {filter_matches_[i_filt]};
+  for (int filt = 0; filt < tally_.n_filters(); filt++) {
+    auto i_filt = tally_.filters(filt);
+    auto& match {filter_matches_[filt]};
     if (!match.bins_present_) {
       match.bins_weights_length_ = 0;
       for (auto i = 0; i < model::tally_filters[i_filt].n_bins(); ++i) {
@@ -173,8 +175,7 @@ FilterBinIter::operator++()
     // can be incremented.
     bool done_looping = true;
     for (int i = tally_.filters().size()-1; i >= 0; --i) {
-      auto i_filt = tally_.filters(i);
-      auto& match {filter_matches_[i_filt]};
+      auto& match {filter_matches_[i]};
       //if (match.i_bin_ < match.bins_.size()-1) {
       if (match.i_bin_ < match.bins_weights_length_-1) {
         // The bin for this filter can be incremented.  Increment it and do not
@@ -221,8 +222,7 @@ FilterBinIter::compute_index_weight()
     index_ = 0;
     weight_ = 1.;
     for (auto i = 0; i < tally_.filters().size(); ++i) {
-      auto i_filt = tally_.filters(i);
-      auto& match {filter_matches_[i_filt]};
+      auto& match {filter_matches_[i]};
       auto i_bin = match.i_bin_;
       index_ += match.bins_[i_bin] * tally_.strides(i);
       weight_ *= match.weights_[i_bin];
@@ -421,8 +421,9 @@ score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
 {
   auto& tally {model::tallies[i_tally]};
   auto i_eout_filt = tally.filters()[tally.energyout_filter_];
-  auto i_bin = p.filter_matches_[i_eout_filt].i_bin_;
-  auto bin_energyout = p.filter_matches_[i_eout_filt].bins_[i_bin];
+  auto& match = p.filter_matches_[tally.energyout_filter_];
+  auto i_bin = match.i_bin_;
+  auto bin_energyout = match.bins_[i_bin];
 
   const Filter& eo_filt {model::tally_filters[i_eout_filt]};
 
@@ -457,7 +458,7 @@ score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
       g_out = eo_filt.n_bins() - g_out - 1;
 
       // change outgoing energy bin
-      p.filter_matches_[i_eout_filt].bins_[i_bin] = g_out;
+      match.bins_[i_bin] = g_out;
 
     } else {
 
@@ -474,7 +475,7 @@ score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
       } else {
         auto i_match = lower_bound_index(eo_filt.bins().begin(),
           eo_filt.bins().end(), E_out);
-        p.filter_matches_[i_eout_filt].bins_[i_bin] = i_match;
+        match.bins_[i_bin] = i_match;
       }
 
     }
@@ -487,8 +488,7 @@ score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
       int filter_index = 0;
       double filter_weight = 1.0;
       for (auto j = 0; j < tally.filters().size(); ++j) {
-        auto i_filt = tally.filters(j);
-        auto& match {p.filter_matches_[i_filt]};
+        auto& match {p.filter_matches_[j]};
         auto i_bin = match.i_bin_;
         filter_index += match.bins_[i_bin] * tally.strides(j);
         filter_weight *= match.weights_[i_bin];
@@ -515,8 +515,7 @@ score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
             // Find the filter index and weight for this filter combination
             double filter_weight = 1.;
             for (auto j = 0; j < tally.filters().size(); ++j) {
-              auto i_filt = tally.filters(j);
-              auto& match {p.filter_matches_[i_filt]};
+              auto& match {p.filter_matches_[j]};
               auto i_bin = match.i_bin_;
               filter_weight *= match.weights_[i_bin];
             }
@@ -533,8 +532,7 @@ score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
         int filter_index = 0;
         double filter_weight = 1.;
         for (auto j = 0; j < tally.filters().size(); ++j) {
-          auto i_filt = tally.filters(j);
-          auto& match {p.filter_matches_[i_filt]};
+          auto& match {p.filter_matches_[j]};
           auto i_bin = match.i_bin_;
           filter_index += match.bins_[i_bin] * tally.strides(j);
           filter_weight *= match.weights_[i_bin];
@@ -548,7 +546,7 @@ score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
   }
 
   // Reset outgoing energy bin and score index
-  p.filter_matches_[i_eout_filt].bins_[i_bin] = bin_energyout;
+  match.bins_[i_bin] = bin_energyout;
 }
 
 double get_nuclide_xs(const Particle& p, int i_nuclide, int score_bin) {


### PR DESCRIPTION
When implementing tallies on device, we have something like:

```C++
  for (int i = 0; i < model::active_tracklength_tallies_size; ++i) {
    int i_tally = model::device_active_tracklength_tallies[i];
    const Tally& tally {model::tallies[i_tally]};

    // Allocate particle FilterMatch array on the stack
    FilterMatch filter_matches[FILTER_MATCHES_SIZE];
    p.filter_matches_ = filter_matches;
```

Where an array of `FilterMatch` objects gets allocated on the stack. The size of the `FILTER_MATCHES_SIZE` macro is fixed at 4. Currently, we are checking to make sure that we don't write off the end of this array by enforcing that the total number of filters in the simulation is less than `FILTER_MATCHES_SIZE`. However, we actually just need to be enforcing that maximum number of filters inside of any _single_ tally is less than 4. I.e., it should be fine if we have 100 tallies each with a unique filter (100 total filters), whereas our current test would trip an assertion in device_alloc.cpp. This PR changes the assertion to check the number of filters per tally rather than on the global number of filters.