### PR TITLE
Restore ability to build without OpenMP

### DIFF
--- a/include/openmc/sort.h
+++ b/include/openmc/sort.h
@@ -81,7 +81,11 @@ void quickSort_parallel(T* arr, int lenArray)
 
   // For OpenMC's use case, we do not see performance gains past 32 threads.
   // So, we will limit the number of threads to 32. 
+  #ifdef _OPENMP
   int	numThreads = std::min({32,omp_get_num_procs()});
+  #else
+  int	numThreads = 1;
+  #endif
 
   #pragma omp parallel num_threads(numThreads)
   {

--- a/include/openmc/vector.h
+++ b/include/openmc/vector.h
@@ -44,7 +44,11 @@ public:
   // Figure out a way around this
   ~vector() {
     if (data_) {
+      #ifdef _OPENMP
       if (omp_is_initial_device()) {
+      #else
+      if (true) {
+      #endif
         this->clear();
         std::free(data_);
       } else {

--- a/src/device_alloc.cpp
+++ b/src/device_alloc.cpp
@@ -93,8 +93,13 @@ void move_read_only_data_to_device()
   // Copy all global settings into device globals
   move_settings_to_device();
 
+  #ifdef _OPENMP
   int host_id = omp_get_initial_device();
   int device_id = omp_get_default_device();
+  #else
+  int host_id = 0;
+  int device_id = 0;
+  #endif
   size_t sz;
 
   // Surfaces ////////////////////////////////////////////////////////

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -396,7 +396,11 @@ bool is_device()
   int is_initial;
   #pragma omp target map(from:is_initial)
   {
+    #ifdef _OPENMP
     is_initial = omp_is_initial_device();
+    #else
+    is_initial = true;
+    #endif
   }
   return !is_initial;
 }


### PR DESCRIPTION
This PR adds a few `_OPENMP` pragmas around openmp intrinsics to restore the ability to compile this branch without OpenMP.