### PR TITLE
Fix for phantom seg fault on A100 and Titan V GPUs

### DIFF
--- a/include/openmc/bremsstrahlung.h
+++ b/include/openmc/bremsstrahlung.h
@@ -23,9 +23,9 @@ public:
   xt::xtensor<double, 2> cdf_; //!< Bremsstrahlung energy CDF
   xt::xtensor<double, 1> yield_; //!< Photon yield
 
-  double* device_pdf_;
-  double* device_cdf_;
-  double* device_yield_;
+  double* device_pdf_ {nullptr};
+  double* device_cdf_ {nullptr};
+  double* device_yield_ {nullptr};
   double pdf(gsl::index i, gsl::index j) const;
   double cdf(gsl::index i, gsl::index j) const;
 };

--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -96,7 +96,7 @@ public:
 
   // Multipole data
   std::unique_ptr<WindowedMultipole> multipole_;
-  WindowedMultipole* device_multipole_;
+  WindowedMultipole* device_multipole_ {nullptr};
   const WindowedMultipole* multipole() const { return device_multipole_; }
 
   // Fission data
@@ -111,7 +111,7 @@ public:
   std::unique_ptr<Function1DFlatContainer> delayed_photons_; //!< Delayed photon energy release
   std::unique_ptr<Function1DFlatContainer> fragments_; //!< Fission fragment energy release
   std::unique_ptr<Function1DFlatContainer> betas_; //!< Delayed beta energy release
-  Function1DFlatContainer* device_total_nu_;
+  Function1DFlatContainer* device_total_nu_ {nullptr};
 
   // Resonance scattering information
   bool resonant_ {false};
@@ -128,7 +128,7 @@ public:
   std::array<size_t, 902> reaction_index_; //!< Index of each reaction
   vector<int> index_inelastic_scatter_;
 
-  ReactionFlatContainer** device_fission_rx_;
+  ReactionFlatContainer** device_fission_rx_ {nullptr};
 private:
   void create_derived(const Function1DFlatContainer* prompt_photons, const Function1DFlatContainer* delayed_photons);
 

--- a/include/openmc/photon.h
+++ b/include/openmc/photon.h
@@ -81,10 +81,10 @@ public:
   xt::xtensor<double, 1> pair_production_nuclear_;
   xt::xtensor<double, 1> heating_;
 
-  double* device_energy_;
-  double* device_coherent_;
-  double* device_incoherent_;
-  double* device_pair_production_total_;
+  double* device_energy_ {nullptr};
+  double* device_coherent_ {nullptr};
+  double* device_incoherent_ {nullptr};
+  double* device_pair_production_total_ {nullptr};
 
   // Form factors
   Tabulated1D incoherent_form_factor_;
@@ -105,10 +105,10 @@ public:
   xt::xtensor<double, 1> electron_pdf_;
 
   size_t n_profile_;
-  double* device_profile_pdf_;
-  double* device_profile_cdf_;
-  double* device_binding_energy_;
-  double* device_electron_pdf_;
+  double* device_profile_pdf_ {nullptr};
+  double* device_profile_cdf_ {nullptr};
+  double* device_binding_energy_ {nullptr};
+  double* device_electron_pdf_ {nullptr};
   double profile_pdf(gsl::index i, gsl::index j) const;
   double profile_cdf(gsl::index i, gsl::index j) const;
 

--- a/include/openmc/thermal.h
+++ b/include/openmc/thermal.h
@@ -71,8 +71,8 @@ private:
     // Data members
     std::unique_ptr<Function1DFlatContainer> xs; //!< Cross section
     std::unique_ptr<AngleEnergyFlatContainer> distribution; //!< Secondary angle-energy distribution
-    Function1DFlatContainer* device_xs;
-    AngleEnergyFlatContainer* device_distribution;
+    Function1DFlatContainer* device_xs {nullptr};
+    AngleEnergyFlatContainer* device_distribution {nullptr};
   };
 
   // Inelastic scattering data

--- a/include/openmc/urr.h
+++ b/include/openmc/urr.h
@@ -23,9 +23,9 @@ public:
   bool multiply_smooth_;          //!< multiply by smooth cross section?
   int n_energy_;                  //!< number of energy points
   xt::xtensor<double, 1> energy_; //!< incident energies
-  double* device_energy_;
+  double* device_energy_ {nullptr};
   xt::xtensor<double, 3> prob_;   //!< Actual probability tables
-  double* device_prob_;
+  double* device_prob_ {nullptr};
   int n_bands_;
   int n_total_prob_;
 

--- a/src/bank.cpp
+++ b/src/bank.cpp
@@ -16,7 +16,7 @@ namespace openmc {
 namespace simulation {
 
 std::vector<Particle::Bank> source_bank;
-Particle::Bank* device_source_bank;
+Particle::Bank* device_source_bank {nullptr};
 
 SharedArray<Particle::Bank> surf_source_bank;
 
@@ -30,7 +30,7 @@ SharedArray<Particle::Bank> fission_bank;
 // this generation for the particle located at that index. This vector is
 // used to efficiently sort the fission bank after each iteration.
 std::vector<int64_t> progeny_per_particle;
-int64_t* device_progeny_per_particle;
+int64_t* device_progeny_per_particle {nullptr};
 
 } // namespace simulation
 

--- a/src/bremsstrahlung.cpp
+++ b/src/bremsstrahlung.cpp
@@ -19,7 +19,7 @@ namespace data {
 xt::xtensor<double, 1> ttb_e_grid;
 xt::xtensor<double, 1> ttb_k_grid;
 
-double* device_ttb_e_grid;
+double* device_ttb_e_grid {nullptr};
 size_t ttb_e_grid_size {0};
 
 } // namespace data

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -34,11 +34,11 @@ namespace openmc {
 
 namespace model {
   std::vector<Cell> cells;
-  Cell* device_cells;
+  Cell* device_cells {nullptr};
   std::unordered_map<int32_t, int32_t> cell_map;
 
   std::vector<Universe> universes;
-  Universe* device_universes;
+  Universe* device_universes {nullptr};
   std::unordered_map<int32_t, int32_t> universe_map;
 } // namespace model
 

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -28,7 +28,7 @@ namespace openmc {
 
 namespace model {
   std::vector<Lattice> lattices;
-  Lattice* device_lattices;
+  Lattice* device_lattices {nullptr};
   std::unordered_map<int32_t, int32_t> lattice_map;
 }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -308,10 +308,10 @@ const Mesh* ufs_mesh {nullptr};
 
 std::vector<double> k_generation;
 std::vector<int64_t> work_index;
-int64_t* device_work_index;
+int64_t* device_work_index {nullptr};
 
 std::vector<Particle>  particles;
-Particle*  device_particles;
+Particle*  device_particles {nullptr};
 
 
 } // namespace simulation

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -27,7 +27,7 @@ namespace openmc {
 namespace model {
   //std::vector<std::unique_ptr<Surface>> surfaces;
   std::vector<Surface> surfaces;
-  Surface* device_surfaces;
+  Surface* device_surfaces {nullptr};
   std::unordered_map<int, int> surface_map;
 } // namespace model
 

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -36,7 +36,7 @@ namespace openmc {
 
 namespace model {
   std::unordered_map<int, int> tally_map;
-  Tally* tallies;
+  Tally* tallies {nullptr};
   size_t tallies_size;
   std::vector<int> active_tallies;
   std::vector<int> active_analog_tallies;
@@ -44,11 +44,11 @@ namespace model {
   std::vector<int> active_collision_tallies;
   std::vector<int> active_meshsurf_tallies;
   std::vector<int> active_surface_tallies;
-  int* device_active_tallies;
+  int* device_active_tallies {nullptr};
   size_t active_tallies_size;
-  int* device_active_collision_tallies;
+  int* device_active_collision_tallies {nullptr};
   size_t active_collision_tallies_size;
-  int* device_active_tracklength_tallies;
+  int* device_active_tracklength_tallies {nullptr};
   size_t active_tracklength_tallies_size;
 }
 

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -29,7 +29,7 @@ namespace openmc {
 namespace data {
 std::unordered_map<std::string, int> thermal_scatt_map;
 std::vector<ThermalScattering> thermal_scatt;
-ThermalScattering* device_thermal_scatt;
+ThermalScattering* device_thermal_scatt {nullptr};
 }
 
 //==============================================================================


### PR DESCRIPTION
This PR fixes a seg fault/CUDA alignment issue that had been causing crashes on the the SXM A100 (ANL Polaris) and Titan V GPUs when compiled with LLVM.

The issue was caused here in thermal.h:

```C++
  struct Reaction {
    // Default constructor
    Reaction() { }

    // Data members
    std::unique_ptr<Function1DFlatContainer> xs; //!< Cross section
    std::unique_ptr<AngleEnergyFlatContainer> distribution; //!< Secondary angle-energy distribution
    Function1DFlatContainer* device_xs;
    AngleEnergyFlatContainer* device_distribution;
  };
```

, specifically due to the lack of initialization in the `device_xs` field. This issue is triggered when we map the reaction data to device as:

```C++
void ThermalScattering::copy_to_device()
{
  data_.copy_to_device();
  for (auto& d : data_) {
    if (d.elastic_.xs) {
      d.elastic_.device_xs = d.elastic_.xs.get();
      d.elastic_.device_distribution = d.elastic_.distribution.get();
      #pragma omp target enter data map(to: d.elastic_.device_xs[:1])
      #pragma omp target enter data map(to: d.elastic_.device_distribution[:1])
      d.elastic_.device_xs->copy_to_device();
      d.elastic_.device_distribution->copy_to_device();
    }

    d.inelastic_.device_xs = d.inelastic_.xs.get();
    d.inelastic_.device_distribution = d.inelastic_.distribution.get();
    #pragma omp target enter data map(to: d.inelastic_.device_xs[:1])
    #pragma omp target enter data map(to: d.inelastic_.device_distribution[:1])
    d.inelastic_.device_xs->copy_to_device();
    d.inelastic_.device_distribution->copy_to_device();
  }
  kTs_.copy_to_device();
}

```

The problem stems from the lines:

```C++
    if (d.elastic_.xs) {
      d.elastic_.device_xs = d.elastic_.xs.get();
```

where we are only initializing the `device_xs` pointer to something if there is actually data that needs to be mapped. Later, during transport, this pointer will be tested to see if it is null or not to determine if we need to process those reactions. If the data is not present, then the pointer didn't get initialized to anything, so we will end up reading from an uninitialized pointer location. Most systems that is going to be 0/null, which is why it was not causing problems on most of the cards we had been developing on. But on some cards it ended up being consistently a "1" value, so we'd read from a garbage location causing the seg fault.

The fix is very easy -- we can just amend the fields to be initialized to `{nullptr}` in thermal.h. I also went ahead to and initialized pointers that are called `device_...` elsewhere in the code, even though this is probably not needed, just to ensure we don't have another seg fault like this lurking out there. Some of the cases I've initialized to `nullptr` I think definitely don't need it due to being globals, but figured it doesn't hurt to make things explicit as it could make grepping for such issues easier down the line.