### PR TITLE
On-Device Sorting for AMD GPUs via HIP Thrust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(device_history "Enable history-based transport on device" OFF)
 option(device_printf  "Enable printf statements on device"       ON)
 option(disable_xs_cache "Disable Micro XS cache"       ON)
 option(cuda_thrust_sort "Enable on-device sorting via CUDA Thrust (NVIDIA devices only)"       OFF)
+option(hip_thrust_sort "Enable on-device sorting via HIP Thrust (AMDdevices only)"       OFF)
 option(sycl_sort "Enable on-device sorting via SYCL OneAPI DPL (Intel devices only)"       OFF)
 
 #===============================================================================
@@ -220,6 +221,9 @@ target_compile_definitions(gsl-lite-v1 INTERFACE gsl_CONFIG_ALLOWS_NONSTRICT_SPA
 set(OPENMC_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include )
 if(cuda_thrust_sort)
   add_subdirectory(cuda_thrust_sort)
+endif()
+if(hip_thrust_sort)
+  add_subdirectory(hip_thrust_sort)
 endif()
 
 
@@ -431,7 +435,7 @@ if(dagmc)
   target_link_libraries(libopenmc dagmc-shared uwuw-shared)
 endif()
 
-if(cuda_thrust_sort)
+if(cuda_thrust_sort OR hip_thrust_sort)
   target_compile_definitions(libopenmc PRIVATE CUDA_THRUST_SORT)
   target_link_libraries(libopenmc openmc_thrust_sort)
 endif()
@@ -489,7 +493,7 @@ configure_file(cmake/OpenMCConfigVersion.cmake.in "${CMAKE_BINARY_DIR}${CMAKE_FI
 
 set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/OpenMC)
 #install(TARGETS openmc libopenmc faddeeva
-if(cuda_thrust_sort)
+if(cuda_thrust_sort OR hip_thrust_sort)
 install(TARGETS openmc libopenmc openmc_thrust_sort
   EXPORT openmc-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(device_history "Enable history-based transport on device" OFF)
 option(device_printf  "Enable printf statements on device"       ON)
 option(disable_xs_cache "Disable Micro XS cache"       ON)
 option(cuda_thrust_sort "Enable on-device sorting via CUDA Thrust (NVIDIA devices only)"       OFF)
-option(hip_thrust_sort "Enable on-device sorting via HIP Thrust (AMDdevices only)"       OFF)
+option(hip_thrust_sort "Enable on-device sorting via HIP Thrust (AMD devices only)"       OFF)
 option(sycl_sort "Enable on-device sorting via SYCL OneAPI DPL (Intel devices only)"       OFF)
 
 #===============================================================================

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -120,6 +120,14 @@
             }
         },
         {
+            "name": "llvm_mi250",
+            "inherits": ["llvm"],
+            "displayName": "LLVM Clang MI250 and MI250X",
+            "environment": {
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a"
+            }
+        },
+        {
             "name": "llvm_mi100_mpi",
             "inherits": ["llvm"],
             "displayName": "LLVM Clang MI100",

--- a/hip_thrust_sort/CMakeLists.txt
+++ b/hip_thrust_sort/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.8.2)
+# Search for rocm in common locations
+if(NOT DEFINED HIP_PATH)
+    if(NOT DEFINED ENV{HIP_PATH})
+        set(HIP_PATH "/opt/rocm/hip" CACHE PATH "Path to which HIP has been installed")
+    else()
+        set(HIP_PATH $ENV{HIP_PATH} CACHE PATH "Path to which HIP has been installed")
+    endif()
+endif()
+set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
+#find_package(hip)
+enable_language(HIP)
+#set(CMAKE_CXX_COMPILER_BACKUP ${CMAKE_CXX_COMPILER})
+#set(CMAKE_CXX_COMPILER /soft/compilers/rocm/rocm-5.4.0/bin/hipcc)
+set(HIP_COMPILER /soft/compilers/rocm/rocm-5.4.0/bin/hipcc)
+
+project(openmc_thrust_sort
+  DESCRIPTION "Sort EventQueueItem arrays in OpenMC on AMD devices with Thrust"
+  LANGUAGES CXX HIP)
+
+list(APPEND openmc_thrust_sort_SOURCES
+  src/openmc_thrust_sort.hip)
+
+add_library(openmc_thrust_sort SHARED ${openmc_thrust_sort_SOURCES})
+  
+target_compile_definitions(openmc_thrust_sort PRIVATE CUDA_THRUST_SORT)
+
+target_include_directories(openmc_thrust_sort PRIVATE ${OPENMC_HEADER_DIR})
+
+set_target_properties(
+    openmc_thrust_sort
+    PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+    COMPILE_FLAGS -O3
+)
+# Link with HIP
+#target_link_libraries(openmc_thrust_sort hip::device)
+
+#set_target_properties(openmc_thrust_sort PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+#set_target_properties(openmc_thrust_sort PROPERTIES GPU_TARGETS "gfx90a")
+
+#set(CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER_BACKUP})

--- a/hip_thrust_sort/CMakeLists.txt
+++ b/hip_thrust_sort/CMakeLists.txt
@@ -8,11 +8,7 @@ if(NOT DEFINED HIP_PATH)
     endif()
 endif()
 set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
-#find_package(hip)
 enable_language(HIP)
-#set(CMAKE_CXX_COMPILER_BACKUP ${CMAKE_CXX_COMPILER})
-#set(CMAKE_CXX_COMPILER /soft/compilers/rocm/rocm-5.4.0/bin/hipcc)
-set(HIP_COMPILER /soft/compilers/rocm/rocm-5.4.0/bin/hipcc)
 
 project(openmc_thrust_sort
   DESCRIPTION "Sort EventQueueItem arrays in OpenMC on AMD devices with Thrust"
@@ -35,10 +31,3 @@ set_target_properties(
     CXX_EXTENSIONS NO
     COMPILE_FLAGS -O3
 )
-# Link with HIP
-#target_link_libraries(openmc_thrust_sort hip::device)
-
-#set_target_properties(openmc_thrust_sort PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-#set_target_properties(openmc_thrust_sort PROPERTIES GPU_TARGETS "gfx90a")
-
-#set(CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER_BACKUP})

--- a/hip_thrust_sort/README.md
+++ b/hip_thrust_sort/README.md
@@ -1,5 +1,5 @@
 This subdirectory contains code and build routines for
-performing on-device sorting via the CUDA Thrust library.
+performing on-device sorting via the HIP Thrust library.
 The use of a separate subdirectory is necessary as OpenMP
 compilers do not know how to link link to Thrust. To avoid
 polluting the main CMakeLists.txt for OpenMC, we have used

--- a/hip_thrust_sort/README.md
+++ b/hip_thrust_sort/README.md
@@ -1,0 +1,8 @@
+This subdirectory contains code and build routines for
+performing on-device sorting via the CUDA Thrust library.
+The use of a separate subdirectory is necessary as OpenMP
+compilers do not know how to link link to Thrust. To avoid
+polluting the main CMakeLists.txt for OpenMC, we have used
+a subdirectory instead to isolate the build for just the 
+thrust portion and then to link to the library that is 
+generated.

--- a/hip_thrust_sort/src/openmc_thrust_sort.hip
+++ b/hip_thrust_sort/src/openmc_thrust_sort.hip
@@ -1,4 +1,4 @@
-#include<thrust/sort.h>
+#include <thrust/sort.h>
 
 // This macro is used to enable the "__host__ __device__" attributes
 // for the EventQueueItem comparator in event.h. If those attributes
@@ -6,7 +6,7 @@
 // of default comparator that does not have the desired effect.
 #define COMPILE_CUDA_COMPARATOR
 
-#include"openmc/event.h"
+#include "openmc/event.h"
 
 namespace openmc{
 

--- a/hip_thrust_sort/src/openmc_thrust_sort.hip
+++ b/hip_thrust_sort/src/openmc_thrust_sort.hip
@@ -1,0 +1,18 @@
+#include<thrust/sort.h>
+
+// This macro is used to enable the "__host__ __device__" attributes
+// for the EventQueueItem comparator in event.h. If those attributes
+// are missing, the code will compile and run, but it will use some sort
+// of default comparator that does not have the desired effect.
+#define COMPILE_CUDA_COMPARATOR
+
+#include"openmc/event.h"
+
+namespace openmc{
+
+void device_sort_event_queue_item(EventQueueItem* begin, EventQueueItem* end)
+{
+  thrust::sort(thrust::device, begin, end);
+}
+
+}


### PR DESCRIPTION
## Overview

In OpenMC, we sort particle queues by material and energy so as to greatly improve the speed of cross section lookup kernels.

By default, particle queues are transferred back to the host, sorted using a thread-parallel quicksort algorithm on the host CPU, and then transferred back to the device. For NVIDIA and Intel architectures, we have the ability to greatly speed up this process by sorting the particle queues in situ on device. For NVIDIA this is been done by linking to the Thrust library, and for Intel this is done by linking to the OneAPI DPL library.

This PR introduces on-device sorting for AMD GPUs as well by linking to the HIP thrust library. The OpenMC source implementation is actually the exact same as with NVIDIA (they are both just making a single call to `thrust::sort`), but there is some small divergence in how the cmake subprojects are set up to compile the sorting operation. 

In my testing on the JLSE MI250 GPU, for a single GCD on the XXL benchmark and 2M particles in-flight, the performance boost is:

Method | Inactive particles/sec
-- | --
Host Sorting | 175,654
On-Device Sorting (This PR) | 250,005

I also added a new compiler preset for the AMD MI250 since we now have some of those nodes at ANL.

## How to Enable

The new HIP sorting for AMD can be enabled by adding `-Dhip_thrust_sort=on` to the cmake line.

## Future work

As we are now able to sort on-device for any of the three main GPU manufacturers, we may want to add some logic to cmake (or alter our CMakePresets.json file) to automatically enable the correct sorting library to link to rather than requiring the user to enable this option manually.
