### PR TITLE
Particle Initialization Fix

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -100,7 +100,7 @@ int openmc_simulation_init()
       std::cout << " Moving particle buffer to device of size: " << simulation::particles.size() * sizeof(Particle) /1.0e6 << " MB. Particle size = " << sizeof(Particle) / 1.0e3 << " KB" << std::endl;
     }
     simulation::device_particles = simulation::particles.data();
-    #pragma omp target enter data map(alloc: simulation::device_particles[:event_buffer_length])
+    #pragma omp target enter data map(to: simulation::device_particles[:event_buffer_length])
   }
 
 


### PR DESCRIPTION
I was running `cuda-memcheck` today and found that we had some reads from uninitialized memory.

The issue stems from how we are mapping particles to device -- namely, that we map them with `alloc` instead of `to`. While most of the fields get initialzed anyway later on via calls to `initialize_history()` and `from_source()`, there are a few fields that needed to be getting the values from their default initializers:

```C++
  double keff_tally_absorption_ {0.0};
  double keff_tally_collision_ {0.0};
  double keff_tally_tracklength_ {0.0};
  double keff_tally_leakage_ {0.0};
```

Once we change the mapping clause to actually copy the initialized particles to the device, then cuda-memcheck runs cleanly.

I think the reason we had `alloc` here is that during the ports early development, we were originally only running certain events on device. As such, we'd be copying particles right before kernel launches, so didn't need to copy them up-front like this.