### PR TITLE
Update Intel Compiler Preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,7 +55,7 @@
             "inherits": ["intel"],
             "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
             "environment": {
-                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device xehp -revision_id 4 -internal_options -ze-opt-large-register-file\" -mllvm -vpo-paropt-atomic-free-reduction=false"
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -mllvm -indvars-widen-indvars=false -Xopenmp-target-backend \"-device 12.60.7\""
             }
         },
         {
@@ -63,7 +63,7 @@
             "inherits": ["intel"],
             "displayName": "Intel GPUs w/Ahead of Time (AOT) Compilation",
             "environment": {
-                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device xehp -revision_id 4\""
+                "PRESET_CXX_FLAGS": "-fopenmp-targets=spir64_gen -Xopenmp-target-backend \"-device 12.60.7\""
             }
         },
         {


### PR DESCRIPTION
Updated the intel compiler preset to target PVC instead of ATS by default. Also added/removed some compiler flags accompanying recent updates in the Intel SDK.

This PR will make OpenMC work again with the ANL Intel CI as the automated testing suite has recently switched to running on sunspot.