### PR TITLE
Change Intel compiler preset to use mpicc instead of icx.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,8 +24,8 @@
             "name": "intel",
             "inherits": ["unity"],
             "cacheVariables": {
-                "CMAKE_C_COMPILER": "icx",
-                "CMAKE_CXX_COMPILER": "icpx"
+                "CMAKE_C_COMPILER": "mpicc",
+                "CMAKE_CXX_COMPILER": "mpic++"
             },
             "environment": {
                 "INTEL_CXX_FLAGS": "-fiopenmp"


### PR DESCRIPTION
Using the MPI wrapper by default is better currently with the sunspot environment. There is not really a good use case for compiling without MPI for Intel either, given that even a single PVC has two tiles.