### PR TITLE
Kernel Launch Optimization

### DIFF
--- a/include/openmc/event.h
+++ b/include/openmc/event.h
@@ -122,7 +122,7 @@ void process_calculate_xs_events_fuel();
 void process_calculate_xs_events_nonfuel();
 
 //! Execute the advance particle event for all particles in this event's buffer
-void process_advance_particle_events(int n_particles);
+void process_advance_particle_events();
 bool depletion_rx_check();
 
 //! Execute the surface crossing event for all particles in this event's buffer

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -186,8 +186,9 @@ void process_calculate_xs_events_nonfuel()
 
   int offset = simulation::advance_particle_queue.size();;
 
+  int n_particles = simulation::calculate_nonfuel_xs_queue.size();
   #pragma omp target teams distribute parallel for
-  for (int i = 0; i < simulation::calculate_nonfuel_xs_queue.size(); i++) {
+  for (int i = 0; i < n_particles; i++) {
     int buffer_idx = simulation::calculate_nonfuel_xs_queue[i].idx;
     Particle& p = simulation::device_particles[buffer_idx];
     p.event_calculate_xs_execute(need_depletion_rx);
@@ -220,8 +221,9 @@ void process_calculate_xs_events_fuel()
 
   int offset = simulation::advance_particle_queue.size();;
 
+  int n_particles = simulation::calculate_fuel_xs_queue.size();
   #pragma omp target teams distribute parallel for
-  for (int i = 0; i < simulation::calculate_fuel_xs_queue.size(); i++) {
+  for (int i = 0; i < n_particles; i++) {
     int buffer_idx = simulation::calculate_fuel_xs_queue[i].idx;
     Particle& p = simulation::device_particles[buffer_idx];
     p.event_calculate_xs_execute(need_depletion_rx);
@@ -238,12 +240,13 @@ void process_calculate_xs_events_fuel()
   simulation::time_event_calculate_xs_fuel.stop();
 }
 
-void process_advance_particle_events(int n_particles)
+void process_advance_particle_events()
 {
   simulation::time_event_advance_particle.start();
 
+  int n_particles = simulation::advance_particle_queue.size();
   #pragma omp target teams distribute parallel for
-  for (int i = 0; i < simulation::advance_particle_queue.size(); i++) {
+  for (int i = 0; i < n_particles; i++) {
     int buffer_idx = simulation::advance_particle_queue[i].idx;
     Particle& p = simulation::device_particles[buffer_idx];
     p.event_advance();
@@ -263,7 +266,7 @@ void process_advance_particle_events(int n_particles)
   if (!model::active_tracklength_tallies.empty()) {
     bool need_depletion_rx = depletion_rx_check();
     #pragma omp target teams distribute parallel for
-    for (int i = 0; i < simulation::advance_particle_queue.size(); i++) {
+    for (int i = 0; i < n_particles; i++) {
       int buffer_idx = simulation::advance_particle_queue[i].idx;
       Particle& p = simulation::device_particles[buffer_idx];
       p.event_tracklength_tally(need_depletion_rx);
@@ -278,8 +281,9 @@ void process_surface_crossing_events()
 {
   simulation::time_event_surface_crossing.start();
 
+  int n_particles = simulation::surface_crossing_queue.size();
   #pragma omp target teams distribute parallel for
-  for (int i = 0; i < simulation::surface_crossing_queue.size(); i++) {
+  for (int i = 0; i < n_particles; i++) {
     int buffer_idx = simulation::surface_crossing_queue[i].idx;
     Particle& p = simulation::device_particles[buffer_idx];
     p.event_cross_surface();
@@ -302,8 +306,9 @@ void process_collision_events()
 {
   simulation::time_event_collision.start();
 
+  int n_particles = simulation::collision_queue.size();
   #pragma omp target teams distribute parallel for
-  for (int i = 0; i < simulation::collision_queue.size(); i++) {
+  for (int i = 0; i < n_particles; i++) {
     int buffer_idx = simulation::collision_queue[i].idx;
     Particle& p = simulation::device_particles[buffer_idx];
     p.event_collide();
@@ -360,8 +365,9 @@ void process_revival_events()
   // Accumulator for particle weights from any sourced particles
   double extra_weight = 0;
 
+  int n_particles = simulation::revival_queue.size();
   #pragma omp target teams distribute parallel for reduction(+:extra_weight)
-  for (int i = 0; i < simulation::revival_queue.size(); i++) {
+  for (int i = 0; i < n_particles; i++) {
     int buffer_idx = simulation::revival_queue[i].idx;
     Particle& p = simulation::device_particles[buffer_idx];
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -910,7 +910,7 @@ void transport_event_based()
     } else if (max == simulation::calculate_nonfuel_xs_queue.size()) {
       process_calculate_xs_events_nonfuel();
     } else if (max == simulation::advance_particle_queue.size()) {
-      process_advance_particle_events(n_particles);
+      process_advance_particle_events();
     } else if (max == simulation::surface_crossing_queue.size()) {
       process_surface_crossing_events();
     } else if (max == simulation::collision_queue.size()) {


### PR DESCRIPTION
The optimization for Intel is related to a fairly "in the weeds" programming issue related to OpenMP and Intel's compiler. Basically, we had a global variable being used as the loop bound in the for loops that are launching the device kernels, e.g.:

```C++
  #pragma omp target teams distribute parallel for
  for (int i = 0; i < simulation::calculate_fuel_xs_queue.size(); i++) {
   ...
```

Apparently this creates ambiguity for the compiler as it isn't sure whether or not to use the host or device version of the queue's `size_` variable. We synchronize the variable between host and device to ensure that both versions have the same value, so it doesn't matter which one gets picked in terms of correctness. However, the Intel compiler has some added logic that gets applied if the loop bound is a device variable which resulted in the kernel getting launched in a suboptimal configuration. The LLVM compiler for NVIDIA and AMD didn't have this issue at all, so it didn't show up during development when we had originally been fiddling with different ways of launching kernels. Anyway, the easy fix is to just read the global into a stack variable and launch the kernel with that, so that the ambiguity is removed, e.g.:

```C++
  int n_particles = simulation::calculate_fuel_xs_queue.size();
  #pragma omp target teams distribute parallel for
  for (int i = 0; i < n_particles; i++) {
   ...
```

This change results in about a 25% overall speedup on Intel, and no significant change on AMD/NVIDIA.

I also removed the `n_particles` argument from one of the event functions to be consistent with the rest of the event functions.