### PR TITLE
CLI options to disable event-based queue sorting

### DIFF
--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -86,8 +86,8 @@ extern "C" int64_t n_particles;              //!< number of particles per genera
 
 extern int64_t max_particles_in_flight; //!< Max num. event-based particles in flight
 
-extern "C" bool sort_fissionable_xs_lookups; //!< Sort fissionable material XS lookups in event-based mode?
-extern "C" bool sort_non_fissionable_xs_lookups; //!< Sort non-fissionable material XS lookups in event-based mode?
+extern bool sort_fissionable_xs_lookups; //!< Sort fissionable material XS lookups in event-based mode?
+extern bool sort_non_fissionable_xs_lookups; //!< Sort non-fissionable material XS lookups in event-based mode?
 
 #pragma omp declare target
 extern ElectronTreatment electron_treatment;       //!< how to treat secondary electrons

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -86,6 +86,9 @@ extern "C" int64_t n_particles;              //!< number of particles per genera
 
 extern int64_t max_particles_in_flight; //!< Max num. event-based particles in flight
 
+extern "C" bool sort_fissionable_xs_lookups; //!< Sort fissionable material XS lookups in event-based mode?
+extern "C" bool sort_non_fissionable_xs_lookups; //!< Sort non-fissionable material XS lookups in event-based mode?
+
 #pragma omp declare target
 extern ElectronTreatment electron_treatment;       //!< how to treat secondary electrons
 extern std::array<double, 4> energy_cutoff;  //!< Energy cutoff in [eV] for each particle type

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -177,7 +177,9 @@ bool depletion_rx_check()
 void process_calculate_xs_events_nonfuel()
 {
   // Sort non fuel lookup queue by material and energy
-  sort_queue(simulation::calculate_nonfuel_xs_queue);
+  if (settings::sort_non_fissionable_xs_lookups) {
+    sort_queue(simulation::calculate_nonfuel_xs_queue);
+  }
 
   simulation::time_event_calculate_xs.start();
   simulation::time_event_calculate_xs_nonfuel.start();
@@ -207,7 +209,9 @@ void process_calculate_xs_events_nonfuel()
 void process_calculate_xs_events_fuel()
 {
   // Sort fuel lookup queue by energy
-  sort_queue(simulation::calculate_fuel_xs_queue);
+  if (settings::sort_fissionable_xs_lookups) {
+    sort_queue(simulation::calculate_fuel_xs_queue);
+  }
 
   // The below line can be used to check if the queue has actually been sorted.
   // May be useful for debugging future on-device sorting strategies.

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -148,6 +148,12 @@ parse_command_line(int argc, char* argv[])
       } else if (arg == "-e" || arg == "--event") {
         settings::event_based = true;
       
+      } else if (arg == "--no-sort-fissionable-xs") {
+        settings::sort_fissionable_xs_lookups = false;
+
+      } else if (arg == "--no-sort-non-fissionable-xs") {
+        settings::sort_non_fissionable_xs_lookups = false;
+
       } else if (arg == "-m" || arg == "--minimum") {
         i += 1;
         settings::minimum_sort_items = std::stoll(argv[i]);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -316,6 +316,8 @@ void print_usage()
       "  -e, --event            Run using event-based parallelism\n"
       "  -m, --minimum          Minimum energy sorting threshold\n"
       "  -i, --inflight         Maximum number of in-flight particles\n"
+      "  --no-sort-fissionable-xs      Do not sort event-based fissionable material xs lookups\n"
+      "  --no-sort-non-fissionable-xs  Do not sort event-based non-fissionable material xs lookups\n"
       "  -v, --version          Show version information\n"
       "  -h, --help             Show this message\n");
   }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -86,6 +86,9 @@ int64_t n_particles {-1};
 
 int64_t max_particles_in_flight {-1};
 
+bool sort_fissionable_xs_lookups {true};
+bool sort_non_fissionable_xs_lookups {true};
+
 ElectronTreatment electron_treatment {ElectronTreatment::TTB};
 std::array<double, 4> energy_cutoff {0.0, 1000.0, 0.0, 0.0};
 int legendre_to_tabular_points {C_NONE};


### PR DESCRIPTION
This PR adds the following CLI options:

```
--no-sort-fissionable-xs       Do not sort event-based fissionable material xs lookups
--no-sort-non-fissionable-xs   Do not sort event-based non-fissionable material xs lookups
```

While fuel XS sorting seems to be pretty much always useful for depleted fuel simulations, sorting before doing non-fuel lookups may or may not be worth it depending on the architecture. Having this as a CLI options makes it a lot easier to experiment with, as previously we had to recompile each time to test this.

As it is a purely performance related option, I don't think it makes sense to include it in the XML interface.