### PR TITLE
Removal of atomic read from find_cell_inner

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -104,7 +104,7 @@ find_cell_inner(Particle& p, const NeighborList* neighbor_list)
       // the element is a 32-bit integer, load and store operations will
       // be implicitly atomic, so a split write is not possible.  
       //
-      // 2) The elememnt begins a "-1". It gets written concurrently to
+      // 2) The elememnt begins as "-1". It gets written concurrently to
       // "42" at the same time this thread reads it. As some caches on
       // GPUs are not cache coherent, a read operation that
       // occurs after the element is set to 42 could result in a -1 being


### PR DESCRIPTION
This PR removes an atomic read operation from the `find_cell_inner()` function. While the read is acceptable, I was finding that some compilers were using overly strict memory ordering with the

```C++
#pragma omp atomic read
```

operation. Specifically, Intel was implementing this as an atomic compare-and-swap operation, which is a lot more expensive than a native atomic read.  Removing the atomic sped up the cross surface kernel by about 2x. It did not result in any performance change on AMD or NVIDIA. Newer versions of the Intel compiler are supposed to have a more intelligent implementation that eliminates the performance problem, but given the logic I've added to the comments of this section, I think it is better to just not use an atomic at all so as to remove the potential for a compiler having a performance regression in its atomics affecting us in the future.