### PR TITLE
Update include/openmc/nuclide.h

### DIFF
--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -22,6 +22,7 @@
 #include "openmc/urr.h"
 #include "openmc/vector.h"
 #include "openmc/wmp.h"
+#include "openmc/material.h"
 
 namespace openmc {
 


### PR DESCRIPTION
The Intel oneAPI compiler fails to compile 'nuclide.cpp' with error

  error: use of undeclared identifier 'model'

This patch adds the missing include to 'nuclide.h'.