### PR TITLE
NULL macro removal

### DIFF
--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -87,7 +87,7 @@ public:
 
   BoundingBox bounding_box() const;
 
-  UniversePartitioner* partitioner_{NULL};
+  UniversePartitioner* partitioner_{nullptr};
 };
 
 //==============================================================================
@@ -232,7 +232,7 @@ public:
   //! rotation angles about the x-, y- and z- axes in degrees, these values are
   //! also present at the end of the vector, making it of length 12.
   //std::vector<double> rotation_;
-  //double* device_rotation_{NULL};
+  //double* device_rotation_{nullptr};
   double rotation_[12];
   int rotation_length_{0};
 
@@ -373,9 +373,9 @@ public:
   //! `surfs_.back()`.  Otherwise, `partitions_[i]` gives cells sandwiched
   //! between `surfs_[i-1]` and `surfs_[i]`.
   std::vector<std::vector<int32_t>> partitions_;
-  int32_t* device_partitions_{NULL};
-  int32_t* device_partitions_offsets_{NULL};
-  int32_t* device_partitions_lengths_{NULL};
+  int32_t* device_partitions_{nullptr};
+  int32_t* device_partitions_offsets_{nullptr};
+  int32_t* device_partitions_lengths_{nullptr};
 };
 
 

--- a/include/openmc/device_alloc.h
+++ b/include/openmc/device_alloc.h
@@ -3,8 +3,6 @@
 
 #include <omp.h>
 #include <assert.h>
-#include <stdlib.h>
-#include <string.h>
 
 namespace openmc {
 

--- a/include/openmc/shared_array.h
+++ b/include/openmc/shared_array.h
@@ -114,10 +114,10 @@ public:
   //! container's size and capacity to 0.
   void clear()
   {
-    if( data_ != NULL )
+    if( data_ != nullptr )
     {
       delete[] data_;
-      data_ = NULL;
+      data_ = nullptr;
     }
     size_ = 0;
     capacity_ = 0;
@@ -194,8 +194,8 @@ public:
 
   //private: 
 
-  T* data_ {NULL}; //!< An RAII handle to the elements
-  T* device_data_ {NULL}; //!< Device pointer for interop with device libraries
+  T* data_ {nullptr}; //!< An RAII handle to the elements
+  T* device_data_ {nullptr}; //!< Device pointer for interop with device libraries
   int size_ {0}; //!< The current number of elements 
   int capacity_ {0}; //!< The total space allocated for elements
 }; 

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -240,7 +240,7 @@ void Universe::allocate_and_copy_to_device()
 {
   cells_.copy_to_device();
 
-  if(partitioner_ != NULL)
+  if(partitioner_ != nullptr)
   {
     // Map partitioner object
     #pragma omp target enter data map(to: partitioner_[:1])


### PR DESCRIPTION
This PR removes the C-style `NULL` macro in favor of the C++ style `nullptr`. The `NULL` was causing test failures with the LLVM compiler. This may have been due to a bug in how LLVM was choosing which macro for `NULL` to use, as apparently there are different ones that get used for C vs. C++. However, I figured it would be best to change over to the C++ style `nullptr` to fix the issue and because it doesn't hurt to use the C++ style expression anyway.

I also removed two unneeded headers from device_alloc.h that may have been causing this problem, as I had been loading the C-style stdlib.h (probably as I may have been using `malloc()` when I first made the device_alloc.cpp file), but this is not needed anymore. I confirmed these headers weren't necessary by compiling both with and without unity.