### PR TITLE
Backport RPN stack removal from #2178

### DIFF
--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -215,10 +215,8 @@ public:
   vector<double> sqrtkT_;
 
   //! Definition of spatial region as Boolean expression of half-spaces
-  vector<std::int32_t> region_;
-  //! Reverse Polish notation for region expression
-  vector<std::int32_t> rpn_;
-  bool simple_;  //!< Does the region contain only intersections?
+  vector<int32_t> region_;
+  bool simple_; //!< Does the region contain only intersections?
 
   //! \brief Neighboring cells in the same universe.
   NeighborList neighbors_;
@@ -244,7 +242,7 @@ protected:
   bool contains_complex(Position r, Direction u, int32_t on_surface) const;
   #pragma omp end declare target
   BoundingBox bounding_box_simple() const;
-  static BoundingBox bounding_box_complex(vector<int32_t> rpn);
+  static BoundingBox bounding_box_complex(vector<int32_t> postfix);
 
   //! Applies DeMorgan's laws to a section of the RPN
   //! \param start Starting point for token modification

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -127,8 +127,13 @@ vector<int32_t>::iterator add_parentheses(
   }
   start++;
 
-  // Initialize return iterator
-  auto return_iterator = infix.begin();
+  // Keep track of return iterator distance. If we don't encounter a left
+  // parenthesis, we return an iterator corresponding to wherever the right
+  // parenthesis is inserted. If a left parenthesis is encountered, an iterator
+  // corresponding to the left parenthesis is returned. Also note that we keep
+  // track of a *distance* instead of an iterator because the underlying memory
+  // allocation may change.
+  std::size_t return_it_dist = 0;
 
   // Add right parenthesis
   // While the start iterator is within the bounds of infix
@@ -141,9 +146,9 @@ vector<int32_t>::iterator add_parentheses(
       // add right parenthesis, right parenthesis position depends on the
       // operator, when the operator is a union then do not include the operator
       // in the region, when the operator is an intersection then include the
-      // operato and next surface
+      // operator and next surface
       if (*start == OP_LEFT_PAREN) {
-        return_iterator = start;
+        return_it_dist = std::distance(infix.begin(), start);
         int depth = 1;
         do {
           start++;
@@ -157,26 +162,29 @@ vector<int32_t>::iterator add_parentheses(
         } while (depth > 0);
       } else {
         start = infix.insert(
-          start_token == OP_UNION ? start - 1 : start, OP_RIGHT_PAREN);
-        if (return_iterator == infix.begin()) {
-          return_iterator = start - 1;
+            start_token == OP_UNION ? start - 1 : start, OP_RIGHT_PAREN);
+        if (return_it_dist > 0) {
+          return infix.begin() + return_it_dist;
+        } else {
+          return start - 1;
         }
-        return return_iterator;
       }
     }
   }
   // If we get here a right parenthesis hasn't been placed,
   // return iterator
   infix.push_back(OP_RIGHT_PAREN);
-  if (return_iterator == infix.begin()) {
-    return_iterator = start - 1;
+  if (return_it_dist > 0) {
+    return infix.begin() + return_it_dist;
+  } else {
+    return start - 1;
   }
-  return return_iterator;
 }
 
 void add_precedence(openmc::vector<int32_t>& infix)
 {
   int32_t current_op = 0;
+  std::size_t current_dist = 0;
 
   for (auto it = infix.begin(); it != infix.end(); it++) {
     int32_t token = *it;
@@ -185,14 +193,21 @@ void add_precedence(openmc::vector<int32_t>& infix)
       if (current_op == 0) {
         // Set the current operator if is hasn't been set
         current_op = token;
+        current_dist = std::distance(infix.begin(), it);
       } else if (token != current_op) {
         // If the current operator doesn't match the token, add parenthesis to assert precedence
-        it = add_parentheses(it, infix);
+        if (current_op == OP_INTERSECTION) {
+          it = add_parentheses(infix.begin() + current_dist, infix);
+        } else {
+          it = add_parentheses(it, infix);
+        }
         current_op = 0;
+        current_dist = 0;
       }
     } else if (token > OP_COMPLEMENT) {
       // If the token is a parenthesis reset the current operator
       current_op = 0;
+      current_dist = 0;
     }
   }
 }

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1124,7 +1124,7 @@ UniversePartitioner::UniversePartitioner(const Universe& univ)
       }
     }
 
-    // If thregion are no bounding z-planes, add this cell to all partitions.
+    // If there are no bounding z-planes, add this cell to all partitions.
     if (lower_token == 0) {
       for (auto& p : partitions_) p.push_back(i_cell);
       continue;

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -111,13 +111,99 @@ tokenize(const std::string region_spec) {
 }
 
 //==============================================================================
+//! Add precedence for infix regions so intersections have higher
+//! precedence than unions using parentheses.
+//==============================================================================
+
+std::vector<int32_t>::iterator add_parentheses(
+  std::vector<int32_t>::iterator start, std::vector<int32_t>& infix)
+{
+  int32_t start_token = *start;
+  // Add left parenthesis
+  if (start_token == OP_INTERSECTION) {
+    start = infix.insert(start - 1, OP_LEFT_PAREN);
+  } else {
+    start = infix.insert(start + 1, OP_LEFT_PAREN);
+  }
+  start++;
+
+  // Initialize return iterator
+  auto return_iterator = infix.begin();
+
+  // Add right parenthesis
+  // While the start iterator is within the bounds of infix
+  while (start < infix.end()) {
+    start++;
+
+    // If the current token is an operator and is different than the start token
+    if (*start >= OP_UNION && *start != start_token) {
+      // Skip wrapped regions but save iterator position to check precedence and
+      // add right parenthesis, right parenthesis position depends on the
+      // operator, when the operator is a union then do not include the operator
+      // in the region, when the operator is an intersection then include the
+      // operato and next surface
+      if (*start == OP_LEFT_PAREN) {
+        return_iterator = start;
+        int depth = 1;
+        do {
+          start++;
+          if (*start > OP_COMPLEMENT) {
+            if (*start == OP_RIGHT_PAREN) {
+              depth--;
+            } else {
+              depth++;
+            }
+          }
+        } while (depth > 0);
+      } else {
+        start = infix.insert(
+          start_token == OP_UNION ? start - 1 : start, OP_RIGHT_PAREN);
+        if (return_iterator == infix.begin()) {
+          return_iterator = start - 1;
+        }
+        return return_iterator;
+      }
+    }
+  }
+  // If we get here a right parenthesis hasn't been placed,
+  // return iterator
+  infix.push_back(OP_RIGHT_PAREN);
+  if (return_iterator == infix.begin()) {
+    return_iterator = start - 1;
+  }
+  return return_iterator;
+}
+
+void add_precedence(std::vector<int32_t>& infix)
+{
+  int32_t current_op = 0;
+
+  for (auto it = infix.begin(); it != infix.end(); it++) {
+    int32_t token = *it;
+
+    if (token == OP_UNION || token == OP_INTERSECTION) {
+      if (current_op == 0) {
+        // Set the current operator if is hasn't been set
+        current_op = token;
+      } else if (token != current_op) {
+        // If the current operator doesn't match the token, add parenthesis to assert precedence
+        it = add_parentheses(it, infix);
+        current_op = 0;
+      }
+    } else if (token > OP_COMPLEMENT) {
+      // If the token is a parenthesis reset the current operator
+      current_op = 0;
+    }
+  }
+}
+
+//==============================================================================
 //! Convert infix region specification to Reverse Polish Notation (RPN)
 //!
 //! This function uses the shunting-yard algorithm.
 //==============================================================================
 
-vector<int32_t>
-generate_rpn(int32_t cell_id, vector<int32_t> infix)
+vector<int32_t> generate_postfix(int32_t cell_id, vector<int32_t> infix)
 {
   vector<int32_t> rpn;
   vector<int32_t> stack;
@@ -471,9 +557,10 @@ Cell::Cell(pugi::xml_node cell_node)
     region_spec = get_node_value(cell_node, "region");
   }
 
-  // Get a tokenized representation of the region specification.
+  // Get a tokenized representation of the region specification and apply De
+  // Morgans law
   region_ = tokenize(region_spec);
-  region_.shrink_to_fit();
+  remove_complement_ops(region_);
 
   // Convert user IDs to surface indices.
   for (auto& r : region_) {
@@ -489,32 +576,28 @@ Cell::Cell(pugi::xml_node cell_node)
     }
   }
 
-  // Convert the infix region spec to RPN.
-  rpn_ = generate_rpn(id_, region_);
-
   // Check if this is a simple cell.
   simple_ = true;
-  for (int32_t token : rpn_) {
-    if ((token == OP_COMPLEMENT) || (token == OP_UNION)) {
+  for (int32_t token : region_) {
+    if (token == OP_UNION) {
       simple_ = false;
+      // Ensure intersections have precedence over unions
+      add_precedence(region_);
       break;
     }
   }
+  region_.shrink_to_fit();
 
   // If this cell is simple, remove all the superfluous operator tokens.
   if (simple_) {
-    size_t i0 = 0;
-    size_t i1 = 0;
-    while (i1 < rpn_.size()) {
-      if (rpn_[i1] < OP_UNION) {
-        rpn_[i0] = rpn_[i1];
-        ++i0;
+    for (auto it = region_.begin(); it != region_.end(); it++) {
+      if (*it == OP_INTERSECTION || *it > OP_COMPLEMENT) {
+        region_.erase(it);
+        it--;
       }
-      ++i1;
     }
-    rpn_.resize(i0);
+    region_.shrink_to_fit();
   }
-  rpn_.shrink_to_fit();
 
   // Read the translation vector.
   if (check_for_node(cell_node, "translation")) {
@@ -596,8 +679,7 @@ Cell::distance(Position r, Direction u, int32_t on_surface, Particle* p) const
   double min_dist {INFTY};
   int32_t i_surf {std::numeric_limits<int32_t>::max()};
 
-  for (int i = 0; i < rpn_.size(); i++) {
-    int32_t token = rpn_[i];
+  for (int32_t token : region_) {
     // Ignore this token if it corresponds to an operator rather than a region.
     if (token >= OP_UNION) continue;
 
@@ -706,9 +788,8 @@ Cell::to_hdf5(hid_t cell_group) const
 
 BoundingBox Cell::bounding_box_simple() const {
   BoundingBox bbox;
-  for (int32_t token : rpn_) {
-    //bbox &= model::surfaces[abs(token)-1].bounding_box(token > 0);
-    bbox &= model::surfaces[std::abs(token)-1].bounding_box(token > 0);
+  for (int32_t token : region_) {
+    bbox &= model::surfaces[abs(token) - 1]->bounding_box(token > 0);
   }
   return bbox;
 }
@@ -716,21 +797,25 @@ BoundingBox Cell::bounding_box_simple() const {
 void Cell::apply_demorgan(vector<int32_t>::iterator start,
                           vector<int32_t>::iterator stop)
 {
-  while (start < stop) {
-    if (*start < OP_UNION) { *start *= -1; }
-    else if (*start == OP_UNION) { *start = OP_INTERSECTION; }
-    else if (*start == OP_INTERSECTION) { *start = OP_UNION; }
+  do {
+    if (*start < OP_UNION) {
+      *start *= -1;
+    } else if (*start == OP_UNION) {
+      *start = OP_INTERSECTION;
+    } else if (*start == OP_INTERSECTION) {
+      *start = OP_UNION;
+    }
     start++;
-  }
+  } while (start < stop);
 }
 
-vector<int32_t>::iterator
-Cell::find_left_parenthesis(vector<int32_t>::iterator start,
-                            const vector<int32_t>& rpn) {
+vector<int32_t>::iterator CSGCell::find_left_parenthesis(
+  vector<int32_t>::iterator start, const vector<int32_t>& infix)
+{
   // start search at zero
   int parenthesis_level = 0;
   auto it = start;
-  while (it != rpn.begin()) {
+  while (it != infix.begin()) {
     // look at two tokens at a time
     int32_t one = *it;
     int32_t two = *(it - 1);
@@ -757,31 +842,44 @@ Cell::find_left_parenthesis(vector<int32_t>::iterator start,
   return it;
 }
 
-void Cell::remove_complement_ops(vector<int32_t>& rpn) {
-  auto it = std::find(rpn.begin(), rpn.end(), OP_COMPLEMENT);
-  while (it != rpn.end()) {
-    // find the opening parenthesis (if any)
-    auto left = find_left_parenthesis(it, rpn);
-    vector<int32_t> tmp(left, it+1);
+void CSGCell::remove_complement_ops(vector<int32_t>& infix)
+{
+  auto it = std::find(infix.begin(), infix.end(), OP_COMPLEMENT);
+  while (it != infix.end()) {
+    // Erase complement
+    infix.erase(it);
+
+    // Define stop given left parenthesis or not
+    auto stop = it;
+    if (*it == OP_LEFT_PAREN) {
+      int depth = 1;
+      do {
+        stop++;
+        if (*stop > OP_COMPLEMENT) {
+          if (*stop == OP_RIGHT_PAREN) {
+            depth--;
+          } else {
+            depth++;
+          }
+        }
+      } while (depth > 0);
+      it++;
+    }
 
     // apply DeMorgan's law to any surfaces/operators between these
     // positions in the RPN
-    apply_demorgan(left, it);
-    // remove complement operator
-    rpn.erase(it);
+    apply_demorgan(it, stop);
     // update iterator position
-    it = std::find(rpn.begin(), rpn.end(), OP_COMPLEMENT);
+    it = std::find(infix.begin(), infix.end(), OP_COMPLEMENT);
   }
 }
 
-BoundingBox Cell::bounding_box_complex(vector<int32_t> rpn) {
-  // remove complements by adjusting surface signs and operators
-  remove_complement_ops(rpn);
-
-  std::vector<BoundingBox> stack(rpn.size());
+BoundingBox CSGCell::bounding_box_complex(vector<int32_t> postfix)
+{
+  vector<BoundingBox> stack(postfix.size());
   int i_stack = -1;
 
-  for (auto& token : rpn) {
+  for (auto& token : postfix) {
     if (token == OP_UNION) {
       stack[i_stack - 1] = stack[i_stack - 1] | stack[i_stack];
       i_stack--;
@@ -799,8 +897,14 @@ BoundingBox Cell::bounding_box_complex(vector<int32_t> rpn) {
   return stack.front();
 }
 
-BoundingBox Cell::bounding_box() const {
-  return simple_ ? bounding_box_simple() : bounding_box_complex(rpn_);
+BoundingBox CSGCell::bounding_box() const
+{
+  if (simple_) {
+    return bounding_box_simple();
+  } else {
+    auto postfix = generate_postfix(this->id_, this->region_);
+    return bounding_box_complex(postfix);
+  }
 }
 
 //==============================================================================
@@ -808,8 +912,7 @@ BoundingBox Cell::bounding_box() const {
 bool
 Cell::contains_simple(Position r, Direction u, int32_t on_surface) const
 {
-  for (int32_t i = 0; i < rpn_.size(); i++) {
-    int32_t token = rpn_[i];
+  for (int32_t token : region_) {
     // Assume that no tokens are operators. Evaluate the sense of particle with
     // respect to the surface and see if the token matches the sense. If the
     // particle's surface attribute is set and matches the token, that
@@ -831,52 +934,59 @@ Cell::contains_simple(Position r, Direction u, int32_t on_surface) const
 bool
 Cell::contains_complex(Position r, Direction u, int32_t on_surface) const
 {
-  // Make a stack of booleans.  We don't know how big it needs to be, but we do
-  // know that rpn.size() is an upper-bound.
-  bool stack[RPN_SIZE];
+  bool in_cell = true;
+  int total_depth = 0;
 
-  int i_stack = -1;
+  // For each token
+  for (auto it = region_.begin(); it != region_.end(); it++) {
+    int32_t token = *it;
 
-  for (int i = 0; i < rpn_.size(); i++) {
-    int32_t token = rpn_[i];
-    // If the token is a binary operator (intersection/union), apply it to
-    // the last two items on the stack. If the token is a unary operator
-    // (complement), apply it to the last item on the stack.
-    if (token == OP_UNION) {
-      stack[i_stack-1] = stack[i_stack-1] || stack[i_stack];
-      i_stack --;
-    } else if (token == OP_INTERSECTION) {
-      stack[i_stack-1] = stack[i_stack-1] && stack[i_stack];
-      i_stack --;
-    } else if (token == OP_COMPLEMENT) {
-      stack[i_stack] = !stack[i_stack];
-    } else {
-      // If the token is not an operator, evaluate the sense of particle with
-      // respect to the surface and see if the token matches the sense. If the
-      // particle's surface attribute is set and matches the token, that
-      // overrides the determination based on sense().
-      i_stack ++;
+    // If the token is a surface evaluate the sense
+    // If the token is a union or intersection check to
+    // short circuit
+    if (token < OP_UNION) {
       if (token == on_surface) {
-        stack[i_stack] = true;
+        in_cell = true;
       } else if (-token == on_surface) {
-        stack[i_stack] = false;
+        in_cell = false;
       } else {
         // Note the off-by-one indexing
-        bool sense = model::device_surfaces[std::abs(token)-1].sense(r, u);
-        stack[i_stack] = (sense == (token > 0));
+        bool sense = model::surfaces[abs(token) - 1]->sense(r, u);
+        in_cell = (sense == (token > 0));
       }
+    } else if ((token == OP_UNION && in_cell == true) ||
+               (token == OP_INTERSECTION && in_cell == false)) {
+      // If the total depth is zero return
+      if (total_depth == 0) {
+        return in_cell;
+      }
+
+      total_depth--;
+
+      // While the iterator is within the bounds of the vector
+      int depth = 1;
+      do {
+        // Get next token
+        it++;
+        int32_t next_token = *it;
+
+        // If the token is an a parenthesis
+        if (next_token > OP_COMPLEMENT) {
+          // Adjust depth accordingly
+          if (next_token == OP_RIGHT_PAREN) {
+            depth--;
+          } else {
+            depth++;
+          }
+        }
+      } while (depth > 0);
+    } else if (token == OP_LEFT_PAREN) {
+      total_depth++;
+    } else if (token == OP_RIGHT_PAREN) {
+      total_depth--;
     }
   }
-
-  if (i_stack == 0) {
-    // The one remaining bool on the stack indicates whether the particle is
-    // in the cell.
-    return stack[i_stack];
-  } else {
-    // This case occurs if there is no region specification since i_stack will
-    // still be -1.
-    return true;
-  }
+  return in_cell;
 }
 
 //==============================================================================

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -143,9 +143,10 @@ partition_universes()
     if (univ.cells_.size() > 10) {
       // Collect the set of surfaces in this universe.
       std::unordered_set<int32_t> surf_inds;
-      for (auto i_cell : univ.cells_) {
-        for (auto token : model::cells[i_cell].rpn_) {
-          if (token < OP_UNION) surf_inds.insert(std::abs(token) - 1);
+      for (auto i_cell : univ->cells_) {
+        for (auto token : model::cells[i_cell]->region_) {
+          if (token < OP_UNION)
+            surf_inds.insert(std::abs(token) - 1);
         }
       }
 

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -143,8 +143,8 @@ partition_universes()
     if (univ.cells_.size() > 10) {
       // Collect the set of surfaces in this universe.
       std::unordered_set<int32_t> surf_inds;
-      for (auto i_cell : univ->cells_) {
-        for (auto token : model::cells[i_cell]->region_) {
+      for (auto i_cell : univ.cells_) {
+        for (auto token : model::cells[i_cell].region_) {
           if (token < OP_UNION)
             surf_inds.insert(std::abs(token) - 1);
         }


### PR DESCRIPTION
This PR is a backport of changes by @myerspat that removed the RPN vector that was used as a stack when evaluating complex CSG cells.

This was found to have a major impact on both performance and practicality of some fusion problems, where complex CSG regions are often used, and CSG regions can commonly be bounded by hundreds of surfaces.

This PR is part of a series of several PRs that I'm putting together to support fixed source transport for fusion problems.