### PR TITLE
Add More CLI Arguments

### DIFF
--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -85,6 +85,7 @@ extern "C" int64_t n_particles;              //!< number of particles per genera
 #pragma omp end declare target
 
 extern int64_t max_particles_in_flight; //!< Max num. event-based particles in flight
+extern double fuel_lookup_bias; //!< Bias against selection of the fuel lookup event (higher means fuel lookup queue must be longer before running)
 
 extern bool sort_fissionable_xs_lookups; //!< Sort fissionable material XS lookups in event-based mode
 extern bool sort_non_fissionable_xs_lookups; //!< Sort non-fissionable material XS lookups in event-based mode

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -89,6 +89,7 @@ extern int64_t max_particles_in_flight; //!< Max num. event-based particles in f
 extern bool sort_fissionable_xs_lookups; //!< Sort fissionable material XS lookups in event-based mode
 extern bool sort_non_fissionable_xs_lookups; //!< Sort non-fissionable material XS lookups in event-based mode
 extern bool sort_surface_crossing; //!< Sort surface crossings in event-based mode
+extern bool sort_on_device; //!< Sort queues on device rather than on host
 
 #pragma omp declare target
 extern ElectronTreatment electron_treatment;       //!< how to treat secondary electrons

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -167,6 +167,10 @@ parse_command_line(int argc, char* argv[])
       } else if (arg == "-i" || arg == "--inflight") {
         i += 1;
         settings::max_particles_in_flight = std::stoll(argv[i]);
+      
+      } else if (arg == "-x" || arg == "--xs-event-bias") {
+        i += 1;
+        settings::fuel_lookup_bias = std::stod(argv[i]);
 
       } else if (arg == "-r" || arg == "--restart") {
         i += 1;

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -156,6 +156,9 @@ parse_command_line(int argc, char* argv[])
       
       } else if (arg == "--no-sort-surface-crossing") {
         settings::sort_surface_crossing = false;
+      
+      } else if (arg == "--no-sort-device") {
+        settings::sort_on_device = false;
 
       } else if (arg == "-m" || arg == "--minimum") {
         i += 1;

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -168,6 +168,10 @@ parse_command_line(int argc, char* argv[])
         i += 1;
         settings::max_particles_in_flight = std::stoll(argv[i]);
       
+      } else if (arg == "-b" || arg == "--n-log-bins") {
+        i += 1;
+        settings::n_log_bins = std::stoi(argv[i]);
+      
       } else if (arg == "-x" || arg == "--xs-event-bias") {
         i += 1;
         settings::fuel_lookup_bias = std::stod(argv[i]);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -455,7 +455,7 @@ void print_runtime()
 
     fmt::print(" Event-Based Fuel XS Queue Bias    = {:.2f}\n", settings::fuel_lookup_bias);
   }
-  fmt::print(" Number of Log Hash Bins           = {:d}\n", settings:n_log_bins);
+  fmt::print(" Number of Log Hash Bins           = {:d}\n", settings::n_log_bins);
 
   fmt::print(" Faddeeva Implementation           = ");
   #ifdef NEW_FADDEEVA

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -443,6 +443,12 @@ void print_runtime()
     fmt::print("GPU Device\n");
   else
     fmt::print("CPU Host\n");
+  
+  fmt::print(" Queue Sorting Location            = ");
+  if (settings::sort_on_device) 
+    fmt::print("GPU Device\n");
+  else 
+    fmt::print("CPU Host\n");
 
   fmt::print(" Faddeeva Implementation           = ");
   #ifdef NEW_FADDEEVA

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -319,6 +319,7 @@ void print_usage()
       "  --no-sort-fissionable-xs      Do not sort event-based fissionable material xs lookups\n"
       "  --no-sort-non-fissionable-xs  Do not sort event-based non-fissionable material xs lookups\n"
       "  --no-sort-surface-crossing    Do not sort event-based surface crossing\n"
+      "  --no-sort-device              Do not sort event-based queues on device (use host instead)\n"
       "  -v, --version          Show version information\n"
       "  -h, --help             Show this message\n");
   }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -320,6 +320,7 @@ void print_usage()
       "  --no-sort-non-fissionable-xs  Do not sort event-based non-fissionable material xs lookups\n"
       "  --no-sort-surface-crossing    Do not sort event-based surface crossing\n"
       "  --no-sort-device              Do not sort event-based queues on device (use host instead)\n"
+      "  -x, --xs-event-bias    Bias against fuel XS lookup event selection (higher means even needs more particles)\n"
       "  -v, --version          Show version information\n"
       "  -h, --help             Show this message\n");
   }
@@ -450,6 +451,8 @@ void print_runtime()
       fmt::print("GPU Device\n");
     else 
       fmt::print("CPU Host\n");
+
+    fmt::print(" Event-Based Fuel XS Queue Bias    = {:.2f}\n", settings::fuel_lookup_bias);
   }
 
   fmt::print(" Faddeeva Implementation           = ");

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -444,11 +444,13 @@ void print_runtime()
   else
     fmt::print("CPU Host\n");
   
-  fmt::print(" Queue Sorting Location            = ");
-  if (settings::sort_on_device) 
-    fmt::print("GPU Device\n");
-  else 
-    fmt::print("CPU Host\n");
+  if (settings::event_based) {
+    fmt::print(" Event-Based Queue Sort Location   = ");
+    if (settings::sort_on_device) 
+      fmt::print("GPU Device\n");
+    else 
+      fmt::print("CPU Host\n");
+  }
 
   fmt::print(" Faddeeva Implementation           = ");
   #ifdef NEW_FADDEEVA

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -321,6 +321,7 @@ void print_usage()
       "  --no-sort-surface-crossing    Do not sort event-based surface crossing\n"
       "  --no-sort-device              Do not sort event-based queues on device (use host instead)\n"
       "  -x, --xs-event-bias    Bias against fuel XS lookup event selection (higher means even needs more particles)\n"
+      "  -b, --n-log-bins       Number of logarithmic hash bins to use for XS lookup acceleration\n"
       "  -v, --version          Show version information\n"
       "  -h, --help             Show this message\n");
   }
@@ -454,6 +455,7 @@ void print_runtime()
 
     fmt::print(" Event-Based Fuel XS Queue Bias    = {:.2f}\n", settings::fuel_lookup_bias);
   }
+  fmt::print(" Number of Log Hash Bins           = {:d}\n", settings:n_log_bins);
 
   fmt::print(" Faddeeva Implementation           = ");
   #ifdef NEW_FADDEEVA

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -89,6 +89,11 @@ int64_t max_particles_in_flight {-1};
 bool sort_fissionable_xs_lookups {true};
 bool sort_non_fissionable_xs_lookups {true};
 bool sort_surface_crossing {true};
+#if defined(CUDA_THRUST_SORT) || defined(SYCL_SORT)
+bool sort_on_device {true};
+#else
+bool sort_on_device {false};
+#endif
 
 ElectronTreatment electron_treatment {ElectronTreatment::TTB};
 std::array<double, 4> energy_cutoff {0.0, 1000.0, 0.0, 0.0};

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -431,6 +431,7 @@ void read_settings_xml()
       if (n_log_bins < 1) {
         fatal_error("Number of bins for logarithmic grid must be greater "
             "than zero.");
+      }
     } else {
       n_log_bins = 4000;
     }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -85,6 +85,7 @@ int32_t gen_per_batch {1};
 int64_t n_particles {-1};
 
 int64_t max_particles_in_flight {-1};
+double fuel_lookup_bias {2.0};
 
 bool sort_fissionable_xs_lookups {true};
 bool sort_non_fissionable_xs_lookups {true};

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -100,7 +100,7 @@ ElectronTreatment electron_treatment {ElectronTreatment::TTB};
 std::array<double, 4> energy_cutoff {0.0, 1000.0, 0.0, 0.0};
 int legendre_to_tabular_points {C_NONE};
 int max_order {0};
-int n_log_bins {4000};
+int n_log_bins {-1};
 int n_batches;
 int n_max_batches;
 ResScatMethod res_scat_method {ResScatMethod::rvs};
@@ -158,7 +158,7 @@ void get_run_parameters(pugi::xml_node node_base)
       max_particles_in_flight = 1000000;
     }
   }
-
+  
   // Get number of basic batches
   if (check_for_node(node_base, "batches")) {
     n_batches = std::stoi(get_node_value(node_base, "batches"));
@@ -421,15 +421,21 @@ void read_settings_xml()
         "multigroup mode");
     }
   }
-
+  
   // Number of bins for logarithmic grid
-  if (check_for_node(root, "log_grid_bins")) {
-    n_log_bins = std::stoi(get_node_value(root, "log_grid_bins"));
-    if (n_log_bins < 1) {
-      fatal_error("Number of bins for logarithmic grid must be greater "
-        "than zero.");
+  // if it wasn't specified as a command-line argument. If it wasn't
+  // set by the user anywhere, set it to a reasonable default value.
+  if (n_log_bins == -1) {
+    if (check_for_node(root, "log_grid_bins")) {
+      n_log_bins = std::stoi(get_node_value(root, "log_grid_bins"));
+      if (n_log_bins < 1) {
+        fatal_error("Number of bins for logarithmic grid must be greater "
+            "than zero.");
+    } else {
+      n_log_bins = 4000;
     }
   }
+
 
   // Number of OpenMP threads
   if (check_for_node(root, "threads")) {

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -842,7 +842,7 @@ void transport_event_based()
   // In practice, this has a several percent improvement in performance, as the fuel lookup
   // event runs more efficiently with more particles in comparison to other events (due to
   // the energy sort for the fuel lookup event which is not used for other events).
-  const int64_t fuel_lookup_bias = 2;
+  //const int64_t fuel_lookup_bias = 2;
 
   // The max revival period forces particles to be revived (if there are any in the revival queue)
   // every nth iteration rather than waiting for this queue to be the largest. While the kernel itself
@@ -904,7 +904,7 @@ void transport_event_based()
     // Require the fuel XS lookup event to be more full to run as compared to other events
     // This is motivated by this event having more benefit to running with more particles
     // due to the particle energy sort.
-    if ( max < fuel_lookup_bias * max_other_than_fuel_xs )
+    if ( static_cast<double>(max) < settings::fuel_lookup_bias * static_cast<double>(max_other_than_fuel_xs) )
       max = max_other_than_fuel_xs;
 
     // Execute event with the longest queue (or revival queue if the revival period is reached)


### PR DESCRIPTION
Dependent on #38 -- recommended to review that one first.

This PR exposes several performance-oriented parameters to OpenMC's command line interface:

- Force host-side sorting, even if compiled with a library capable of device-side queue sorting
- XS Lookup event biasing (At 1.0, the XS fuel lookup event is as likely to be selected to run as any other event). As it is increased above 1.0, it requires more particles to be queued for XS fuel lookup before being selected. As XS lookups involve a more expensive sort, and benefit more when the queue is fuller and locality is more improved, increasing a bit (default 2.0) helps make sure the event buffer is fuller than it would normally be at 1.0.
- Logarithmic hash bin count (was already exposed via XML setting, but CLI is much easier to alter quickly when testing this parameter via script or optimization library)

The immediate purpose of adding these in is to facilitate usage of the `ytopt` machine learning library for automatic parameter optimization on both Aurora and Frontier. While these parameters could in theory be added to the XML interface as well, as they do not affect the simulation results (only performance), it makes sense to leave them as CLI arguments.

The new CLI in summary looks like:

```
Usage: openmc [options] [directory]

Options:
  -c, --volume           Run in stochastic volume calculation mode
  -g, --geometry-debug   Run with geometry debugging on
  -n, --particles        Number of particles per generation
  -p, --plot             Run in plotting mode
  -r, --restart          Restart a previous run from a state point
                         or a particle restart file
  -s, --threads          Number of OpenMP threads
  -t, --track            Write tracks for all particles
  -e, --event            Run using event-based parallelism
  -m, --minimum          Minimum energy sorting threshold
  -i, --inflight         Maximum number of in-flight particles
  --no-sort-fissionable-xs      Do not sort event-based fissionable material xs lookups
  --no-sort-non-fissionable-xs  Do not sort event-based non-fissionable material xs lookups
  --no-sort-surface-crossing    Do not sort event-based surface crossing
  --no-sort-device              Do not sort event-based queues on device (use host instead)
  -x, --xs-event-bias    Bias against fuel XS lookup event selection (higher means even needs more particles)
  -b, --n-log-bins       Number of logarithmic hash bins to use for XS lookup acceleration
  -v, --version          Show version information
  -h, --help             Show this message
```