### PR TITLE
Remove unneeded non-flat reaction product sample function

### DIFF
--- a/include/openmc/reaction_product.h
+++ b/include/openmc/reaction_product.h
@@ -42,13 +42,6 @@ public:
   //! \param[in] group HDF5 group containing data
   explicit ReactionProduct(hid_t group);
 
-  //! Sample an outgoing angle and energy
-  //! \param[in] E_in Incoming energy in [eV]
-  //! \param[out] E_out Outgoing energy in [eV]
-  //! \param[out] mu Outgoing cosine with respect to current direction
-  //! \param[inout] seed Pseudorandom seed pointer
-  void sample(double E_in, double& E_out, double& mu, uint64_t* seed) const;
-
   void serialize(DataBuffer& buffer) const;
 
   Particle::Type particle_; //!< Particle type

--- a/src/reaction_product.cpp
+++ b/src/reaction_product.cpp
@@ -82,35 +82,6 @@ ReactionProduct::ReactionProduct(hid_t group)
   }
 }
 
-void ReactionProduct::sample(double E_in, double& E_out, double& mu,
-  uint64_t* seed) const
-{
-  auto n = applicability_.size();
-  if (n > 1) {
-    double prob = 0.0;
-    double c = prn(seed);
-    for (int i = 0; i < n; ++i) {
-      // Determine probability that i-th energy distribution is sampled
-      prob += applicability_[i](E_in);
-
-      // If i-th distribution is sampled, sample energy from the distribution
-      if (c <= prob) {
-        #pragma omp target map(from: E_out, mu) map(tofrom: seed[:1])
-        {
-          distribution_[i]->sample(E_in, E_out, mu, seed);
-        }
-        break;
-      }
-    }
-  } else {
-    // If only one distribution is present, go ahead and sample it
-    #pragma omp target map(from: E_out, mu) map(tofrom: seed[:1])
-    {
-      distribution_[0]->sample(E_in, E_out, mu, seed);
-    }
-  }
-}
-
 void ReactionProduct::serialize(DataBuffer& buffer) const
 {
   buffer.add(static_cast<int>(particle_));             // 4


### PR DESCRIPTION
This PR removes a vestigial non-flat `ReactionProduct::sample()` function, which is not called. Rather, the `ReactionProductFlat::sample()` function is used. It is useful to remove as the function contained a target region that was added for testing purposed when the reactions were being ported.