### PR TITLE
Multiple Temperature Dataset Fix

### DIFF
--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -198,9 +198,7 @@ public:
           // Randomly sample between temperature i and i+1
           f = (kT - kTs_[i_temp]) / (kTs_[i_temp + 1] - kTs_[i_temp]);
 
-          //TODO: to maintain the same random number stream as the Fortran code this
-          //replaces, the seed is set with index_ + 1 instead of index_
-          double sample = future_prn(static_cast<int64_t>(index_ + 1), p.seeds_[STREAM_SAB_T]);
+          double sample = future_prn(static_cast<int64_t>(index_), p.seeds_[STREAM_SAB_T]);
 
           if (f > sample) ++i_temp;
           break;
@@ -341,9 +339,9 @@ public:
       double sab_elastic;
       double sab_inelastic;
           
-      //TODO: to maintain the same random number stream as the Fortran code this
-      //replaces, the seed is set with index_ + 1 instead of index_
-      double sample = future_prn(static_cast<int64_t>(index_ + 1), p.seeds_[STREAM_SAB_T]);
+      // Generate a sample from the SAB stream, in case it is needed for temperature
+      // interpolation
+      double sample = future_prn(static_cast<int64_t>(index_), p.seeds_[STREAM_SAB_T]);
 
       data::device_thermal_scatt[i_sab].calculate_xs(E, sqrtkT, &sab_i_temp, &sab_elastic, &sab_inelastic, sample);
 

--- a/include/openmc/random_lcg.h
+++ b/include/openmc/random_lcg.h
@@ -10,13 +10,15 @@ namespace openmc {
 // Module constants.
 //==============================================================================
 
-constexpr int N_STREAMS         {6};
+constexpr int N_STREAMS         {8};
 constexpr int STREAM_TRACKING   {0};
 constexpr int STREAM_TALLIES    {1};
 constexpr int STREAM_SOURCE     {2};
 constexpr int STREAM_URR_PTABLE {3};
 constexpr int STREAM_VOLUME     {4};
 constexpr int STREAM_PHOTON     {5};
+constexpr int STREAM_RESONANT_T {6};
+constexpr int STREAM_SAB_T      {7};
 constexpr int64_t DEFAULT_SEED  {1};
 
 //==============================================================================

--- a/include/openmc/thermal.h
+++ b/include/openmc/thermal.h
@@ -102,7 +102,7 @@ public:
   //! \param[inout] seed Pseudorandom seed pointer
   #pragma omp declare target
   void calculate_xs(double E, double sqrtkT, int* i_temp, double* elastic,
-                    double* inelastic, uint64_t* seed) const;
+                    double* inelastic, double sample) const;
   #pragma omp end declare target
 
   //! Determine whether table applies to a particular nuclide

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -215,6 +215,13 @@ Particle::event_calculate_xs_dispatch()
 void
 Particle::event_calculate_xs_execute(bool need_depletion_rx)
 {
+  // Forward resonant and SAB temperature sampling seeds
+  stream_ = STREAM_RESONANT_T;
+  advance_prn_seed(data::nuclides_size, current_seed());
+  stream_ = STREAM_SAB_T;
+  advance_prn_seed(data::nuclides_size, current_seed());
+  stream_ = STREAM_TRACKING;
+
   model::materials[material_].calculate_xs(*this, need_depletion_rx);
 }
 

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -148,7 +148,7 @@ ThermalScattering::ThermalScattering(hid_t group, const std::vector<double>& tem
 void
 ThermalScattering::calculate_xs(double E, double sqrtkT, int* i_temp,
                                 double* elastic, double* inelastic,
-                                uint64_t* seed) const
+                                double sample) const
 {
   // Determine temperature for S(a,b) table
   double kT = sqrtkT*sqrtkT;
@@ -166,7 +166,7 @@ ThermalScattering::calculate_xs(double E, double sqrtkT, int* i_temp,
     } else {
       // Randomly sample between temperature i and i+1
       double f = (kT - kTs_[i]) / (kTs_[i+1] - kTs_[i]);
-      if (f > prn(seed)) ++i;
+      if (f > sample) ++i;
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue when using a dataset with multiple temperatures that occurs when interpolating between temperature levels.

As we sample temperature levels stochastically, we end up with different temperature index selections between calls to calculate_xs. This is problematic as the macro XS data we compute during the normal calculate XS event then no longer matches to what will be calculated when sampling particles in the collision kernel. The net result of the bug is that we often fail to sample nuclides, and even if we do sample them, it is likely not statistically correct.

Thankfully, the fix is pretty easy -- we simply use the same idea that we use for URR probability table sampling, where a separate random stream is maintained that is only forwarded occasionally rather than every time a variate is generated. This PR adds two streams (one for resonant temperature sampling, one for SAB temperature sampling), which are forwarded at the beginning of the calculate xs execution event. This guarantees that the same nuclide temperatures will be selected as long as the macro XS remains the same.

With the fix in place, it appears to fix the correctness/crashing issues. There is some performance loss, not due to the extra sampling, but rather due to that I had been doing performance testing with the single temperature NNDC data set. Thankfully, the performance loss due to interpolation seems small, about 10%, which results from having to load twice as much XS data in per warp as was previously done as threads will be loading from various temperature levels now.

Below is some testing done on an A100 for the SMR problem, reporting active batch particles/sec:

  | ENDF vii.1 (six temp) | NNDC (single temp)
-- | -- | --
SMR Multipole | 187,789 | 209,491
SMR No Multipole | 174,531 | 200,621

There is also the potential for further loss of performance when multiphysics feedback is present in this model, as currently the entire reactor is at 531K. This will mean that different threads may not just be loading from two different temperature levels, but possibly from 3 or 4. That said, the additional losses are probably fairly small, and we can probably easily fix any additional losses by modifying our particle sort to include an estimated resonant temperature index, such that threads within a warp are then likely to be between the same two energy levels. It would be good to test out an SMR with some strawman variation in fuel temperatures to see what happens, and if a sorting optimization is even necessary.

Note -- I also changed the way we sample the RNG in the nuclide calculate_xs function to directly load the correct seed, rather than changing the particle's stream back/forth. This was done to cut down on the number of global memory loads/stores, given that particle data sits in global memory.
