### PR TITLE
Increase neighbor list size

### DIFF
--- a/include/openmc/neighbor_list.h
+++ b/include/openmc/neighbor_list.h
@@ -7,7 +7,7 @@
 #include <mutex>
 #include <assert.h>
 
-#define NEIGHBOR_SIZE 13 // limited by SMR
+#define NEIGHBOR_SIZE 50 // limited by fusion models
 
 namespace openmc{
 


### PR DESCRIPTION
This PR increases the neighbor list size from 13 to 50, to allow for more flexibility with fusion benchmark problems. It likely may need to be increased again in the future, but this at least allows the UKAEA fusion benchmark test to run cleanly.