### PR TITLE
Add fissionable check to pointwise XS lookups

### DIFF
--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -278,8 +278,13 @@ public:
       // Perform Interpolation
       total       = f_comp * total_low       + f * total_next;
       absorption  = f_comp * absorption_low  + f * absorption_next;
-      fission     = f_comp * fission_low     + f * fission_next;
-      nu_fission  = f_comp * nu_fission_low  + f * nu_fission_next;
+      if (fissionable_) {
+        fission     = f_comp * fission_low     + f * fission_next;
+        nu_fission  = f_comp * nu_fission_low  + f * nu_fission_next;
+      } else {
+        fission = 0.0;
+        nu_fission = 0.0;
+      }
       photon_prod = f_comp * photon_prod_low + f * photon_prod_next;
 
       // Depletion-related reactions


### PR DESCRIPTION
In the main branch of OpenMC, we have a check when performing pointwise XS lookups to just set `fission` and `nu_fission` to zero if `fissionable_` is false. In our offloading branch, this test isn't present. I'm not sure if this can cause issues, or if the underlying nuclide fission/nu_fission data is zero already, but worth adding this in to maintain the same logic.