### PR TITLE
Xtensor template fix

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,7 +39,7 @@
                 "CMAKE_CXX_COMPILER": "clang++"
             },
             "environment": {
-                "LLVM_CXX_FLAGS": "-fopenmp -fopenmp-cuda-mode"
+                "LLVM_CXX_FLAGS": "-fopenmp -fopenmp-cuda-mode -fno-relaxed-template-template-args"
             }
         },
         {


### PR DESCRIPTION
This is a workaround for newer versions of LLVM that are having some sort of interaction with xtensor that is causing issues. Notably, this will also affect the main development branch of OpenMC eventually, though is much more of a present issue for the OMP fork given our reliance on newer compilers.

The intertwined issues are a little hard to parse, but I'm gathering that the issue may be in xtensor itself rather than with LLVM, but I'm not 100% on that.

Thankfully, there is an easy workaround flag that can be passed to LLVM that fixes the error. I think we should add it in now so that our auto testing works again and I'll plan on checking manually now and then to see if the flag is still required or not (and/or if an update to the xtensor submodule fixes it).

See issues:
- https://github.com/llvm/llvm-project/issues/91504
- https://github.com/xtensor-stack/xtensor/issues/2783