### PR TITLE
Fix GPU memory leak when OpenMC is run multiple times in library mode

### DIFF
--- a/include/openmc/shared_array.h
+++ b/include/openmc/shared_array.h
@@ -113,20 +113,6 @@ public:
     return idx;
   }
 
-  //! Free any space that was allocated for the container. Set the
-  //! container's size and capacity to 0.
-  void clear()
-  {
-    if( data_ != nullptr )
-    {
-      free_on_device();
-      delete[] data_;
-      data_ = nullptr;
-    }
-    size_ = 0;
-    capacity_ = 0;
-  }
-
   //! Return the number of elements in the container
   int size() {return size_;}
   
@@ -197,6 +183,20 @@ public:
   {
     #pragma omp target update from(data_[:capacity_])
     #pragma omp target update from(size_)
+  }
+
+  //! Free any space that was allocated for the container. Set the
+  //! container's size and capacity to 0.
+  void clear()
+  {
+    if( data_ != nullptr )
+    {
+      free_on_device();
+      delete[] data_;
+      data_ = nullptr;
+    }
+    size_ = 0;
+    capacity_ = 0;
   }
   
   //==========================================================================

--- a/include/openmc/shared_array.h
+++ b/include/openmc/shared_array.h
@@ -72,6 +72,9 @@ public:
   //! \param capacity The number of elements to allocate in the container
   void reserve(int capacity)
   {
+    if (capacity <= capacity_) {
+      return;
+    }
     data_ = new T[capacity];
     capacity_ = capacity;
   }
@@ -116,6 +119,7 @@ public:
   {
     if( data_ != nullptr )
     {
+      free_on_device();
       delete[] data_;
       data_ = nullptr;
     }
@@ -175,6 +179,12 @@ public:
     
     // If OpenMP 5.1 is fully supported, we can more simply just do:
     //device_data_ = static_cast<T*>(omp_get_mapped_ptr(data_, omp_get_default_device()));
+  }
+
+  //! Free allocated memory on device
+  void free_on_device()
+  {
+    #pragma omp target exit data map(delete: data_[:capacity_])
   }
 
   void copy_host_to_device()


### PR DESCRIPTION
As part of multiphysics work, I had noticed that there was a significant GPU memory leak when OpenMC is run multiple times as a library, e.g.,

```C++
  for( int i = 0; i < 100; i++)
    err = openmc_run();
```

I tracked this down to our `SharedArray` class -- specifically the `reserve` function. The function was previously assuming that the `SharedArray` was of zero capacity and with no data allocated for it yet. This PR actually checks the current capacity and avoids allocating a new pointer if unnecessary. This allows multiple calls to reserve() with the same capacity without leaking memory.

Note that if a `SharedArray` were to have a capacity greater than zero, and reserve() is called with an even higher capacity, this will result in a memory leak. However, that use case doesn't currently happen in OpenMC. Down the line though, we can fix that issue, e.g., if we want to adjust the number of particles/batch between multiphysics iterations. I'd like to hold off on making that enhancement though until I have a tangible test case I can validate it with.

With this fix, we are at least now able to run multiple library calls without increasing memory footprint.