### PR TITLE
Force transfer of openmc::vector data when mapped multiple times

### DIFF
--- a/include/openmc/vector.h
+++ b/include/openmc/vector.h
@@ -174,12 +174,7 @@ public:
     std::swap(data_, other.data_);
   }
 
-  void copy_to_device() {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wopenmp-mapping"
-#pragma omp target enter data map(to: data_[:size_])
-#pragma GCC diagnostic pop
-  }
+
 
   void allocate_on_device() {
 #pragma GCC diagnostic push
@@ -193,6 +188,14 @@ public:
 #pragma GCC diagnostic ignored "-Wopenmp-mapping"
 #pragma omp target update to(data_[:size_])
 #pragma GCC diagnostic pop
+  }
+
+  void copy_to_device() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wopenmp-mapping"
+#pragma omp target enter data map(alloc: data_[:size_])
+#pragma GCC diagnostic pop
+  update_to_device();
   }
 
   void update_from_device() {


### PR DESCRIPTION
Currently when OpenMC is called in library mode and run multiple times (e.g., for multiphysics work), any updates to host data structures between calls to `openmc_run()` are not propagating to device, despite being mapped. While the mapping routines are still being run again each time, transfers are not occurring as we'd like. This is due to use of the:

```C++
#pragma omp target enter data map(to: data_[:size_])
```

directive, which checks to see if `data_` has already been mapped to that length, and will not move the data again if it is already present on device. To actually move the data when this call is made multiple times, this PR changes this to an `alloc` mapping with a subsequent `update` clause. Thus, the first time it is run, we will `alloc` + `update`, whereas subsequent mapping routines will result in the `alloc` having no impact, but the `update` forcing data to actually be refreshed.

Longer term, it would be more efficient to avoid re-mapping of data at all. While it doesn't result in a memory leak, moving all vector data from host -> device each multiphysics iteration is probably more than necessary. It would be better to track/detect if certain data structures have been modified and just move those, or perhaps only re-copy data structures that are exposed to the API (e.g., materials, cells, universes, tallies). For now though, the unnecessary copies usually are not very time consuming, so won't impact overall multiphysics simulation runtimes very significantly at all.