### PR TITLE
Remove xtensor argument

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,7 +39,7 @@
                 "CMAKE_CXX_COMPILER": "clang++"
             },
             "environment": {
-                "LLVM_CXX_FLAGS": "-fopenmp -fopenmp-cuda-mode -fno-relaxed-template-template-args"
+                "LLVM_CXX_FLAGS": "-fopenmp -fopenmp-cuda-mode"
             }
         },
         {


### PR DESCRIPTION
This PR removes the `-fno-relaxed-template-template-args` argument that was added as a stopgap in #52. This was being used to fix a problem in xtensor and LLVM 19. The current build of LLVM (LLVM 21) doesn't need this argument to work anymore -- and also has removed this argument so gives an error if it is passed (it had been deprecated for awhile).

This PR will cause OpenMC to no longer work with LLVM19 -- however, once https://github.com/xtensor-stack/xtensor/pull/2821 is merged in to xtensor we can just update to that xtensor version to get OpenMC working again with LLVM 19. It is better not to wait until that is merged so that CI testing of the nightly LLVM build can continue. Those wanting to build the GPU offloading version of OpenMC specifically with LLVM 19 can just add the argument back in in the interim, though hopefully the xtensor fix will get merged soon.